### PR TITLE
Fix up django markup to prevent display errors

### DIFF
--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -68,7 +68,14 @@
             {% endblock header_banner %}
         </header>
 
-        {% if level_1 %} {% block second_level_nav %} {% endblock second_level_nav %} {% endif %} {% block header %}{% endblock %} {% block content_container %} {% block outer_content %} {% endblock outer_content %} {% endblock content_container %} {% include
-        "_base/footer.html" %} {% block footer_extra %}{% endblock %}
+        {% block header %}
+        {% endblock %}
+
+        {% block content_container %}
+            {% block outer_content %}
+            {% endblock outer_content %}
+        {% endblock content_container %}
+
+        {% include "_base/footer.html" %}
     </body>
 </html>


### PR DESCRIPTION
## Done

Fixed indentation of django include markup to fix error that was preventing footer partial from displaying.
## QA

Run code and check that footer displays.
