### PR TITLE
Bump Ubuntu Vanilla Theme to 0.0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "author": "Canonical webteam",
   "license": "LGPL v3",
   "dependencies": {
-    "ubuntu-vanilla-theme": "0.0.17"
+    "ubuntu-vanilla-theme": "0.0.19"
   }
 }


### PR DESCRIPTION
This is to pull in styling for full width containers.
