### PR TITLE
Links in images should point to www.ubuntu.com

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,12 +27,12 @@
                     <div class="intro-left"></div>
                     <div class="intro-middle">
                         <ul class="ubuntu-intro__list no-bullets inline">
-                            <li><a class="intro-cloud" href="/cloud">Cloud</a></li>
-                            <li><a class="intro-server" href="/server">Server</a></li>
-                            <li><a class="intro-desktop" href="/desktop">Desktop</a></li>
-                            <li><a class="intro-phone" href="/phone">Phone</a></li>
-                            <li><a class="intro-tablet" href="/tablet">Tablet</a></li>
-                            <li><a class="intro-iot" href="/things" id="IoT-homepage">Things</a></li>
+                            <li><a class="intro-cloud" href="http://www.ubuntu.com/cloud">Cloud</a></li>
+                            <li><a class="intro-server" href="http://www.ubuntu.com/server">Server</a></li>
+                            <li><a class="intro-desktop" href="http://www.ubuntu.com/desktop">Desktop</a></li>
+                            <li><a class="intro-phone" href="http://www.ubuntu.com/phone">Phone</a></li>
+                            <li><a class="intro-tablet" href="http://www.ubuntu.com/tablet">Tablet</a></li>
+                            <li><a class="intro-iot" href="http://www.ubuntu.com/things" id="IoT-homepage">Things</a></li>
                         </ul>
                     </div>
                     <div class="intro-right"></div>
@@ -68,17 +68,17 @@
         <div class="four-col prepend-two last-col">
             <div class="cloud-tools-container not-for-small">
                 <div class="cloud-tools-list">
-                    <a class="item-one" href="/cloud/openstack" title="OpenStack">OpenStack</a>
+                    <a class="item-one" href="http://www.ubuntu.com/cloud/openstack" title="OpenStack">OpenStack</a>
                     <span class="item-line item-one-line"></span>
-                    <a class="item-two" href="/cloud/openstack/managed-cloud" title="BootStack">BootStack</a>
+                    <a class="item-two" href="http://www.ubuntu.com/cloud/openstack/managed-cloud" title="BootStack">BootStack</a>
                     <span class="item-line item-two-line"></span>
-                    <a class="item-three" href="/cloud/tools/juju" title="Juju">Juju</a>
+                    <a class="item-three" href="http://www.ubuntu.com/cloud/tools/juju" title="Juju">Juju</a>
                     <span class="item-line item-three-line"></span>
-                    <a class="item-four" href="/cloud/tools/maas" title="MAAS">MAAS</a>
+                    <a class="item-four" href="http://www.ubuntu.com/cloud/tools/maas" title="MAAS">MAAS</a>
                     <span class="item-line item-four-line"></span>
-                    <a class="item-five" href="/cloud/openstack/autopilot" title="Autopilot">Autopilot</a>
+                    <a class="item-five" href="http://www.ubuntu.com/cloud/openstack/autopilot" title="Autopilot">Autopilot</a>
                     <span class="item-line item-five-line"></span>
-                    <a class="item-six" href="/cloud/public-cloud" title="Public cloud">Public cloud</a>
+                    <a class="item-six" href="http://www.ubuntu.com/cloud/public-cloud" title="Public cloud">Public cloud</a>
                     <span class="item-line item-six-line"></span>
                     <span class="item-seven">Ubuntu</span>
                 </div>


### PR DESCRIPTION
jp.ubuntu.com has just gone live but there are many broken links.

This hopefully fixes them all.
## QA

Load index and click on any of the cloud, server etc. images.
