### PR TITLE
Remove targets from links in images

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,12 +27,12 @@
                     <div class="intro-left"></div>
                     <div class="intro-middle">
                         <ul class="ubuntu-intro__list no-bullets inline">
-                            <li><a class="intro-cloud" href="http://www.ubuntu.com/cloud">Cloud</a></li>
-                            <li><a class="intro-server" href="http://www.ubuntu.com/server">Server</a></li>
-                            <li><a class="intro-desktop" href="http://www.ubuntu.com/desktop">Desktop</a></li>
-                            <li><a class="intro-phone" href="http://www.ubuntu.com/phone">Phone</a></li>
-                            <li><a class="intro-tablet" href="http://www.ubuntu.com/tablet">Tablet</a></li>
-                            <li><a class="intro-iot" href="http://www.ubuntu.com/things" id="IoT-homepage">Things</a></li>
+                            <li><a class="intro-cloud" title="Cloud">Cloud</a></li>
+                            <li><a class="intro-server"title="Server">Server</a></li>
+                            <li><a class="intro-desktop" title="Desktop">Desktop</a></li>
+                            <li><a class="intro-phone" title="Phone">Phone</a></li>
+                            <li><a class="intro-tablet" title="Tablet">Tablet</a></li>
+                            <li><a class="intro-iot" title="Things" id="IoT-homepage">Things</a></li>
                         </ul>
                     </div>
                     <div class="intro-right"></div>
@@ -68,17 +68,17 @@
         <div class="four-col prepend-two last-col">
             <div class="cloud-tools-container not-for-small">
                 <div class="cloud-tools-list">
-                    <a class="item-one" href="http://www.ubuntu.com/cloud/openstack" title="OpenStack">OpenStack</a>
+                    <a class="item-one" title="OpenStack">OpenStack</a>
                     <span class="item-line item-one-line"></span>
-                    <a class="item-two" href="http://www.ubuntu.com/cloud/openstack/managed-cloud" title="BootStack">BootStack</a>
+                    <a class="item-two" title="BootStack">BootStack</a>
                     <span class="item-line item-two-line"></span>
-                    <a class="item-three" href="http://www.ubuntu.com/cloud/tools/juju" title="Juju">Juju</a>
+                    <a class="item-three" title="Juju">Juju</a>
                     <span class="item-line item-three-line"></span>
-                    <a class="item-four" href="http://www.ubuntu.com/cloud/tools/maas" title="MAAS">MAAS</a>
+                    <a class="item-four" title="MAAS">MAAS</a>
                     <span class="item-line item-four-line"></span>
-                    <a class="item-five" href="http://www.ubuntu.com/cloud/openstack/autopilot" title="Autopilot">Autopilot</a>
+                    <a class="item-five" title="Autopilot">Autopilot</a>
                     <span class="item-line item-five-line"></span>
-                    <a class="item-six" href="http://www.ubuntu.com/cloud/public-cloud" title="Public cloud">Public cloud</a>
+                    <a class="item-six" title="Public cloud">Public cloud</a>
                     <span class="item-line item-six-line"></span>
                     <span class="item-seven">Ubuntu</span>
                 </div>


### PR DESCRIPTION
Apparently the images shouldn't link to www.ubuntu.com in this case.

The styling, however, is applied to anchors, so I'm leaving them as anchors for now.
## QA

Check the images aren't links
