### PR TITLE
Updates blog module to 1.3.5 to fix 404 on article pages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.0.2
 canonicalwebteam.http==1.0.1
-canonicalwebteam.blog==1.3.4
+canonicalwebteam.blog==1.3.5
 talisker==0.11.1
 python-dateutil==2.8.0
 raven[flask]==6.10.0


### PR DESCRIPTION
## Done

- Update blog module to 1.3.5 to include https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/32

Fixes https://github.com/canonical-web-and-design/jp.ubuntu.com/issues/136

## QA

- `./run`
- go to `http://localhost:8012/blog/running-android-with-amazon-ec2-a1-instances-cn` and make sure it displays (is chinese content, and not japanese)
