### PR TITLE
Hide latest news until javascript is working

### DIFF
--- a/static/js/latest-news.js
+++ b/static/js/latest-news.js
@@ -25,12 +25,14 @@ function htmlForLatestArticles(articles) {
       </p>`;
     const div = document.createElement("div");
     div.classList.add("col-3");
-    div.innerHTML = ` 
+    div.innerHTML = `
         ${header}
         ${date}
       `;
 
     articlesTree.appendChild(div);
+    var strip = document.getElementById("latest-news-strip");
+    strip.classList.remove("u-hide");
   }
   return articlesTree;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,7 +53,7 @@
       </div>
     </div>
   </section>
-  <section class="p-strip is-deep is-bordered">
+  <section id="latest-news-strip" class="p-strip is-deep is-bordered u-hide">
     {% include "shared/_latest-news.html"%}
   </section>
 


### PR DESCRIPTION
## Done

- Hide latest news strip until there is news to be added

## QA

1. download this branch
2. run the site
3. look at the homepage http://0.0.0.0:8012/
4. turn off javascript and reload the homepage
5. see that the row is hidden

## Issue / Card

Fixes #130

## Screenshots

**without**
![image](https://user-images.githubusercontent.com/441217/56748142-36393a00-6777-11e9-98d9-19d36ef0bcad.png)

