### PR TITLE
Temporary redirect to english pricing page

### DIFF
--- a/templates/enterprise-support/index.html
+++ b/templates/enterprise-support/index.html
@@ -14,8 +14,8 @@
       <h1>Ubuntu Advantageエンタープライズ向けサポート</h1>
       <p>Canonicalが提供するUbuntu Advantageは、お客様のエンタープライズ向けUbuntuのデプロイをサポートおよび保証します。Ubuntu Advantageは、ツール、ビットストリーム、サポートサービスなどが含まれた多様なパッケージで利用できます。ほとんどのパッケージには、Landscape（セキュリティ監査とコンプライアンスのためのUbuntuシステム管理ツール）と、Canonical Livepatch Service（Ubuntuシステムを再起動せずにクリティカルなカーネルの修正を適用可能）が含まれています。</p>
       <p>
-        <a href="/contact-us?product=support" class="p-button--positive"><span class="p-link--external">お問い合わせ</span></a>
-        <a href="/enterprise-support/plans-and-pricing" class="p-button--neutral">プランと価格</a>
+        <a href="/contact-us?product=support" class="p-button--positive">お問い合わせ</a>
+        <a href="/enterprise-support/plans-and-pricing" class="p-button--neutral p-link--external">プランと価格</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -163,7 +163,7 @@
         <li class="p-list__item is-ticked">Canonical livepatch service</li>
       </ul>
       <p>
-        <a href="/enterprise-support/plans-and-pricing#landscape" class="p-button--positive">Landscapeのプランと価格</a>
+        <a href="/enterprise-support/plans-and-pricing#landscape" class="p-button--positive p-link--external">Landscapeのプランと価格</a>
       </p>
     </div>
   </div>
@@ -200,7 +200,7 @@
     <div class="col-8">
       <h2>Ubuntu Advantageの入手</h2>
       <p>Livepatch、Extended Security Maintenance、Landscapeシステム管理はすべてUbuntu Advantageで提供されます。お客様の企業のニーズに最適なサポートパッケージをお勧めします。</p>
-      <p><a href="/enterprise-support/plans-and-pricing" class="p-button--positive">プランと価格</a> <a href="/contact-us/product=ua" class="p-button--neutral">お問い合わせ</a></p>
+      <p><a href="/enterprise-support/plans-and-pricing" class="p-button--positive p-link--external">プランと価格</a> <a href="/contact-us/product=ua" class="p-button--neutral">お問い合わせ</a></p>
     </div>
     <div class="col-4 u-hide--small u-align--center u-vertically-center">
       <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/eb4f6183-picto-safety-orange.svg" width="150" alt="Community">
@@ -213,7 +213,7 @@
       <div class="col-4 p-divider__block">
         <h3 class="p-heading--four">プランと価格</h3>
         <p>Canonicalの製品とサービスに関する詳細</p>
-        <a href="/enterprise-support/plans-and-pricing" class="p-button--positive">プランと価格</a>
+        <a href="/enterprise-support/plans-and-pricing" class="p-button--positive p-link--external">プランと価格</a>
       </div>
       <div class="col-4 p-divider__block">
         <h3 class="p-heading--four">コミュニティサポート</h3>


### PR DESCRIPTION
## Done

* Temporary redirect from `/enterprise-support/plans-and-pricing` to https://www.ubuntu.com/pricing until translation is updated.
* Removal of `p-external--link` class on contact button.

Edit: This happens to be blocked by #142