### PR TITLE
Remove font import from base as it is in the sass already

### DIFF
--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -22,7 +22,6 @@
 
   <link type="text/plain" rel="author" href="{{ versioned_static( 'files/humans.txt') }}" />
 
-  <link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,500&amp;subset=japanese" rel="stylesheet">
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static( 'css/styles.css') }}" />
   {% block head_extra %}{% endblock %}
 </head>


### PR DESCRIPTION
## Done

- remove link to font in base template

## QA

1. download
2. run the site
3. see that the Noto font is loaded at the correct weights from the sass

## Issue / Card

Fixes #101

