### PR TITLE
Fix some 404 links to contact-us

### DIFF
--- a/templates/enterprise-support/index.html
+++ b/templates/enterprise-support/index.html
@@ -200,7 +200,7 @@
     <div class="col-8">
       <h2>Ubuntu Advantageの入手</h2>
       <p>Livepatch、Extended Security Maintenance、Landscapeシステム管理はすべてUbuntu Advantageで提供されます。お客様の企業のニーズに最適なサポートパッケージをお勧めします。</p>
-      <p><a href="/enterprise-support/plans-and-pricing" class="p-button--positive p-link--external">プランと価格</a> <a href="/contact-us/product=ua" class="p-button--neutral">お問い合わせ</a></p>
+      <p><a href="/enterprise-support/plans-and-pricing" class="p-button--positive p-link--external">プランと価格</a> <a href="/contact-us?product=ua" class="p-button--neutral">お問い合わせ</a></p>
     </div>
     <div class="col-4 u-hide--small u-align--center u-vertically-center">
       <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/eb4f6183-picto-safety-orange.svg" width="150" alt="Community">

--- a/templates/enterprise-support/plans-and-pricing.html
+++ b/templates/enterprise-support/plans-and-pricing.html
@@ -585,7 +585,7 @@
     </div>
   </div>
   <div class="row">
-    <p><a href="/contact-us/product=openstack" class="p-button--neutral">お問い合わせ</a></p>
+    <p><a href="/contact-us?product=openstack" class="p-button--neutral">お問い合わせ</a></p>
     <p><a href="#consulting">CanonicalのOpenstackコンサルティングパッケージを見る&nbsp;&rsaquo;</a></p>
   </div>
 </section>
@@ -717,7 +717,7 @@
       <div class="col-12">
         <p><small><sup>*</sup> 最低価格が適用されます</small></p>
         <p><small><sup>**</sup> BootStack（マネージドOpenStack）の価格はマネージドKubernetesの価格（2,190ドル）に追加されます。無制限の数の仮想KubernetesノードをそれぞれのOpenStack物理ノード上で実行できます。物理ノードに対してOpenStack向けUbuntu Advantageを購入済みの場合は、Kubernetes向けUbuntu Advantageは追加料金不要です。</small></p>
-        <p><a href="/contact-us/product=kubernetes" class="p-button--neutral">Kubernetesに関するお問い合わせ</a></p>
+        <p><a href="/contact-us?product=kubernetes" class="p-button--neutral">Kubernetesに関するお問い合わせ</a></p>
         <p><a href="#consulting">CanonicalのKubernetesコンサルティングパッケージを見る&nbsp;&rsaquo;</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

[List of steps to QA the new features or prove the bug has been resolved]
- access to https://jp.ubuntu.com/enterprise-support
- click "お問い合わせ" in the last half of the page to see if it's accessible or 404

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

![image](https://user-images.githubusercontent.com/4356209/59361023-2c41b980-8d6c-11e9-993e-5176e70c6d4d.png)

