### PR TITLE
Update pricing on Kubernetes enterprise support packages

### DIFF
--- a/templates/kubernetes.html
+++ b/templates/kubernetes.html
@@ -416,15 +416,15 @@
             <tr>
               <td>ノードあたりの価格（物理） <sup><a href="#fn-ks">*</a></sup></td>
               <td class="u-align--center">0ドル</td>
-              <td class="p-table__cell--highlight u-align--center">600ドル/年</td>
-              <td class="p-table__cell--highlight u-align--center">1,200ドル/年</td>
+              <td class="p-table__cell--highlight u-align--center">750ドル/年</td>
+              <td class="p-table__cell--highlight u-align--center">1,500ドル/年</td>
               <td class="p-table__cell--highlight u-align--center">4,380ドル/年</td>
             </tr>
             <tr>
               <td>ノードあたりの価格 (virtual) <sup><a href="#fn-ks">*</a></sup></td>
               <td class="u-align--center">0ドル</td>
-              <td class="p-table__cell--highlight u-align--center">200ドル/年</td>
-              <td class="p-table__cell--highlight u-align--center">400ドル/年</td>
+              <td class="p-table__cell--highlight u-align--center">250ドル/年</td>
+              <td class="p-table__cell--highlight u-align--center">500ドル/年</td>
               <td class="p-table__cell--highlight u-align--center">1,460ドル/年</td>
             </tr>
             <tr>


### PR DESCRIPTION
## Done

Updated pricing of the support for enterprises section in the main Kubernetes page. 

## QA

Check out this feature branch
Run the site using the command ./run serve
View the site locally in your web browser at: http://0.0.0.0:8012/kubernetes#supported-packages
Run through the following QA steps:
- Please ensure that the prices are correct.

## Issue / Card

Fixes #159