### PR TITLE
Update enterprise support index page to match copy doc

### DIFF
--- a/templates/enterprise-support/index.html
+++ b/templates/enterprise-support/index.html
@@ -68,7 +68,7 @@
       <li class="p-matrix__item">
         <div class="p-matrix__content">
           <h3 class="p-matrix__title p-heading--four">ESM</h3>
-          <p class="p-matrix__desc">Ubuntu 12.04 LTSのユーザーは<a href="#esm">Extended Security Maintenance (ESM)</a>によって、安全なプライベートアーカイブを通じたカーネルのセキュリティ修正を継続的に受けられます。</p>
+          <p class="p-matrix__desc">Ubuntu 12.04 LTSと14.04 LTSのユーザーは<a href="#esm">Extended Security Maintenance (ESM)</a>によって、安全なプライベートアーカイブを通じたカーネルのセキュリティ修正を継続的に受けられます。</p>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -129,8 +129,8 @@
   <div class="row u-equal-height" id="esm">
     <div class="col-7">
       <h3>Extended Security maintenance</h3>
-      <p>CanonicalのUbuntuセキュリティチームによって、「high」および「critical」のCVE（共通脆弱性識別子）に対する修正プログラムが、Ubuntuメインアーカイブで通常使用されるサーバーパッケージ向けに提供されます。ESM（Extended Security Maintenance）は、安全なプライベートアーカイブを通じてUbuntu 12.04 LTSユーザーがこれまで取得していたセキュリティアップデートを継続して提供します。</p>
-      <p>2017年4月に、Ubuntu 12.04 LTSは終了しました。新しいバージョンのUbuntu ServerにアップグレードできないUbuntu Advantageのお客様に対して、CanonicalはUbuntu 12.04 ESMを提供しています。ESMでは、2019年4月までカーネルおよび重要なパッケージに対してセキュリティ修正を継続的に提供します。</p>
+      <p>CanonicalのUbuntuセキュリティチームによって、「high」および「critical」のCVE（共通脆弱性識別子）に対する修正プログラムが、Ubuntuメインアーカイブで通常使用されるサーバーパッケージ向けに提供されます。ESM（Extended Security Maintenance）は、安全なプライベートアーカイブを通じてUbuntu 12.04 LTSと14.04 LTSユーザーがこれまで取得していたセキュリティアップデートを継続して提供します。</p>
+      <p>2017年4月に、Ubuntu 12.04 LTSと14.04 LTSは終了しました。新しいバージョンのUbuntu ServerにアップグレードできないUbuntu Advantageのお客様に対して、CanonicalはUbuntu 12.04 ESMを提供しています。ESMでは、2019年4月までカーネルおよび重要なパッケージに対してセキュリティ修正を継続的に提供します。</p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
       <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/9e59756d-shield-ESM.svg" width="150" alt="">


### PR DESCRIPTION
## Done

Updated enterprise support index page to match copy doc (added "と14.04 LTS" to each instance of "12.04 LTS")

## QA

- Check out this feature branch
- Run the site using the command ./run serve
- View the site locally in your web browser at: http://0.0.0.0:8012/enterprise-support
- Run through the following QA steps
- Please ensure the changes are reflected on the takeover:
  - The page matches the [copy doc](https://docs.google.com/document/d/1xmk7zYUzWILnbW3RxGtC9c9stYYEFtKBytETlIgyHYE/edit#)

## Issue / Card

Fixes #152