### PR TITLE
Add social metadata to header for twitter/opengraph

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -5,6 +5,29 @@
 
 {% block meta_description %}{{ article.excerpt.raw | truncate (159, True, '&hellip;') | striptags }}{% endblock %}
 
+{% block head_extra %}
+  <meta name="theme-color" content="#E95420" />
+  <meta name="twitter:account_id" content="4503599627481511" />
+  <meta name="twitter:site" content="@ubuntu">
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://jp.ubuntu.com{{ request.get_full_path }}" />
+  <meta property="og:site_name" content="Ubuntu Japan" />
+
+  {% if article.title.rendered %}
+      <meta name="twitter:title" content="{{ article.title.rendered|safe }}">
+      <meta property="og:title" content="{{ article.title.rendered|safe }}" />
+  {% endif %}
+  {% if article.excerpt.raw  %}
+      <meta name="twitter:description" content="{{ article.excerpt.raw | truncate (159, True, '&hellip;') | striptags }}">
+      <meta property="og:description" content="{{ article.excerpt.raw | truncate (159, True, '&hellip;') | striptags }}" />
+  {% endif %}
+  {% if article.image.source_url %}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:image" content="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}">
+      <meta property="og:image" content="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}" />
+  {% endif %}
+{% endblock %}
+
 {% block outer_content %}
 <section id="main-content" class="p-strip">
   <div class="row">


### PR DESCRIPTION
## Done

- Add social meta data to header for twitter and opengraph

## QA

- download this branch
- run the site
- look at a [blog post](http://0.0.0.0:8012/blog/%e4%bc%81%e6%a5%ad%e3%81%ab%e3%82%88%e3%82%8b%e3%82%ab%e3%82%b9%e3%82%bf%e3%83%9e%e3%82%a4%e3%82%ba%e3%81%ab%e5%af%be%e5%bf%9c%e3%81%99%e3%82%8b%e6%ac%a1%e4%b8%96%e4%bb%a3%e3%83%89%e3%83%ad%e3%83%bc)
- See that the social info is there

## Issue / Card

Fixes #163