### PR TITLE
update the download page to 19.10

### DIFF
--- a/templates/download.html
+++ b/templates/download.html
@@ -49,11 +49,11 @@
       </div>
     </div>
     <div class="col-6 p-card">
-      <h3 class="p-card__title">Ubuntu Desktop 19.04</h3>
+      <h3 class="p-card__title">Ubuntu Desktop 19.10</h3>
       <div class="p-card__content">
-        <p>デスクトップPCおよびノートPC向けのUbuntuオペレーティングシステムの最新バージョンです。Ubuntu 19.04 では、2019年7月までの9か月間、セキュリティアップデートおよびメンテナンスアップデートが提供されます</p>
-        <p><a class="p-button--neutral row" href="https://www.ubuntu.com/download/desktop/thank-you/?version=19.04&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
-        <p><a class="p-link--external" href="https://wiki.ubuntu.com/DiscoDingo/ReleaseNotes">Ubuntu 19.04 release notes</a></p>
+        <p>デスクトップPCおよびノートPC向けのUbuntuオペレーティングシステムの最新バージョンです。Ubuntu 19.10 では、2020年7月までの9か月間、セキュリティアップデートおよびメンテナンスアップデートが提供されます</p>
+        <p><a class="p-button--neutral row" href="https://www.ubuntu.com/download/desktop/thank-you/?version=19.10&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-link--external" href="https://wiki.ubuntu.com/EoanErmine/ReleaseNotes">Ubuntu 19.10 release notes</a></p>
       </div>
     </div>
   </div>
@@ -88,11 +88,11 @@
       </div>
     </div>
     <div class="col-6 p-card">
-      <h3 class="p-card__title">Ubuntu Server 19.04</h3>
+      <h3 class="p-card__title">Ubuntu Server 19.10</h3>
       <div class="p-card__content">
-        <p>Ubuntu Serverの最新バージョンです。2019年7月までの9か月のセキュリティアップデートとメンテナンスアップデートが含まれます。</p>
-        <p><a class="p-button--neutral row" href="https://www.ubuntu.com/download/server/thank-you/?version=19.04&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
-        <p><a class="p-link--external" href="https://wiki.ubuntu.com/DiscoDingo/ReleaseNotes">Ubuntu 19.04 release notes</a></p>
+        <p>Ubuntu Serverの最新バージョンです。2020年7月までの9か月のセキュリティアップデートとメンテナンスアップデートが含まれます。</p>
+        <p><a class="p-button--neutral row" href="https://www.ubuntu.com/download/server/thank-you/?version=19.10&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-link--external" href="https://wiki.ubuntu.com/EoanErmine/ReleaseNotes">Ubuntu 19.10 release notes</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Update the text and link from 19.04 to 19.10.

jp.ubuntu.com's equivalent to:
https://github.com/canonical-web-and-design/ubuntu.com/pull/5954

## QA

Click the download link and check if the download starts **once** 19.10 is officially released.