### PR TITLE
set active page on /contact-us

### DIFF
--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -1,4 +1,5 @@
 {% extends "_base/base.html" %}
+{% set active_page = "contact-us" %}
 
 {% block title %}お問い合わせフオーム | Ubuntu{% endblock %}
 


### PR DESCRIPTION
## Done

- set `active_page` variable on /contact-us

## QA

- Check out this branch
- `./run` the project
- Visit http://0.0.0.0:8012/contact-us
- See that the last item in the top nav is highlighted/active (compared to [live site](https://jp.ubuntu.com/contact-us))

## Issue / Card

Fixes #181 
