### PR TITLE
Robotics engage

### DIFF
--- a/templates/engage/robotics_whitepaper.html
+++ b/templates/engage/robotics_whitepaper.html
@@ -8,7 +8,7 @@
 
 {% block outer_content %}
 
-{% with  title="ロボットのオペレーティングシステムを選ぶ際に考慮すべきポイント",  image="https://assets.ubuntu.com/v1/39ebd977-robot.svg", image_width="195", url="#register-section", cta="ダウンロード", class="p-takeover--robotics" %}
+{% with  title="ロボットのオペレーティングシステムを選ぶ際に考慮すべきポイント",  image="https://assets.ubuntu.com/v1/39ebd977-robot.svg", image_width="120", url="#register-section", cta="ダウンロード", class="p-takeover--robotics" %}
   {% include "engage/shared/_header.html" %}
 {% endwith %}
 

--- a/templates/engage/robotics_whitepaper.html
+++ b/templates/engage/robotics_whitepaper.html
@@ -1,0 +1,52 @@
+{% extends "_base/base.html" %}
+
+{% block title %}ロボットのオペレーティングシステムを選ぶ際に考慮すべきポイント | Ubuntu{% endblock %}
+
+{% block meta_description %}ロボットに用いるOSの選定は、本稼働においてその性能に影響を与えます。長期的に、安定して収益性の高いロボットの寿命を確保するためには、適切なOSが必要です。{% endblock %}
+
+{% block meta_image %}https://assets.ubuntu.com/v1/65f2218f-Embedded+social+media+banner.jpg{% endblock %}
+
+{% block outer_content %}
+
+{% with  title="ロボットのオペレーティングシステムを選ぶ際に考慮すべきポイント",  image="https://assets.ubuntu.com/v1/39ebd977-robot.svg", image_width="195", url="#register-section", cta="ダウンロード", class="p-takeover--robotics" %}
+  {% include "engage/shared/_header.html" %}
+{% endwith %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>技術的な進歩、市場需要の増大、あるいは単に「カッコいいから」と理由は何であれ、ヘルスケアから、産業、小売まで、多くの業界にロボットが採用されています。</p>
+
+      <p>「IDCによると、ハードウェア、ソフトウェア、関連サービスなど、ロボットに対する投資は、2021年までに世界で2,307億米ドルに達すると見込まれています。」</p>
+        
+      <p>幅広いIoT業界と同様、このトレンドの影響から、スタートアップ企業であれ実績ある大企業であれ、生産されるロボットの数は必然的に増加しています。</p>
+        
+      <p>ロボットメーカーは、OSが開発の速度と効率性に与える影響、および本稼働でどれだけの性能を発揮するかを検討したうえで、長期的に安定したサポートができる製品を提供しなければなりません。このような検討事項は、変化と競争の激しい市場ではさらに重要となります。</p>
+        
+      <p>このホワイトペーパーでは、下記のポイントについて詳細をお読みいただけます。</p>
+        
+      <ul class="p-list">
+        <li class="p-list__item">貴社のエンジニアのスキルを最大化し活用することで、開発プロセスを促進</li>
+        <li class="p-list__item">その他のインフラやハードウェアをスムーズに統合し、互換性を向上、摩擦を軽減</li>
+        <li class="p-list__item">安定して収益性の高いロボットの寿命を長期間確保</li>
+      </ul>
+    </div>
+    <div class="col-5" id="register-section">
+      <h3>ダウンロード</h3>
+      {% with 
+        id="3444", 
+        returnURL="" 
+      %}
+        {% include "engage/shared/_form.html"%}
+      {% endwith %}
+    </div>
+  </div>
+</section>
+
+<style>
+  .p-takeover--robotics {
+    color: #ffffff;
+    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+  }
+</style>
+{% endblock %}

--- a/templates/engage/robotics_whitepaper.html
+++ b/templates/engage/robotics_whitepaper.html
@@ -35,7 +35,7 @@
       <h3>ダウンロード</h3>
       {% with 
         id="3444", 
-        returnURL="" 
+        returnURL="https://pages.ubuntu.com/Robotics_Whitepaper_JapanTY.html" 
       %}
         {% include "engage/shared/_form.html"%}
       {% endwith %}

--- a/templates/engage/robotics_whitepaper.html
+++ b/templates/engage/robotics_whitepaper.html
@@ -35,7 +35,7 @@
       <h3>ダウンロード</h3>
       {% with 
         id="3444", 
-        returnURL="https://pages.ubuntu.com/Robotics_Whitepaper_JapanTY.html" 
+        returnURL="https://assets.ubuntu.com/v1/761d79ae-Robotics-Japan-WP_Canonical_07.11.19.pdf" 
       %}
         {% include "engage/shared/_form.html"%}
       {% endwith %}

--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -20,7 +20,7 @@
       </div>
     </div>
     {% if image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{% if image != "http" %}{{ ASSET_SERVER_URL }}{% endif %}{{ image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="image for (( title ))" >
+      <img src="{% if image != "http" %}{{ ASSET_SERVER_URL }}{% endif %}{{ image }}" width="{% if image_width %}{{ image_width }}{% else %}413{% endif %}" style="max-height: 410px; max-width: 250px;" alt="image for (( title ))" >
     </div>{% endif %}
   </div>
 </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,11 +7,10 @@
 {% block outer_content %}
   <!-- Section 1: Hero -->
   <template id="takeovers" class="u-hide">
-
     {% include "takeovers/_sbi-takeover.html" %}
     {% include "takeovers/_yahoo-takeover.html" %}
     {% include "takeovers/_openstack-made-easy-takeover.html" %}
-
+    {% include "takeovers/_robotics-takeover.html" %}
   </template>
 
   <!-- Default Takeover: Download the latest Ubuntu -->

--- a/templates/takeovers/_robotics-takeover.html
+++ b/templates/takeovers/_robotics-takeover.html
@@ -1,0 +1,25 @@
+<section class="p-strip--image js-takeover is-dark p-takeover--robotics">
+  <div class="row u-vertically-center">
+    <div class="col-8 u-fade-left--medium">
+      <h1>適切なロボットOSの選択</h1>
+      <p class="u-no-padding--top p-heading--four">開発・本稼働における要点の分析</p>
+      <a href="/engage/robotics_whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=2)CY19_IOT_Robotics_Whitepaper_Japan" class="p-button--positive">ホワイトペーパーをダウンロードする</a>
+    </div>
+    <div class="col-4 u-hide--small u-align--center u-vertically-center" >
+      <img src="https://assets.ubuntu.com/v1/39ebd977-robot.svg" alt="Robot">
+    </div>
+  </div>
+  <style>
+    .p-takeover--robotics {
+      background-image: url(https://assets.ubuntu.com/v1/e6a2c401-suru-left.svg), url(https://assets.ubuntu.com/v1/a9dab044-suru-right.svg), linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+      background-position: left, right;
+      background-repeat: no-repeat, no-repeat;
+      background-size: auto 100%, auto 100%, cover;
+    }
+    @media (max-width: 874px) {
+      .p-takeover--robotics {
+        background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+      }
+    }
+  </style>
+</section>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -18,6 +18,14 @@ class TestRoutes(unittest.TestCase):
 
         self.assertEqual(self.client.get("/").status_code, 200)
 
+    def test_iot_page(self):
+        """
+        When given the iot page URL,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/iot").status_code, 200)
+
     def test_not_found(self):
         """
         When given a non-existent URL,

--- a/webapp/blueprint.py
+++ b/webapp/blueprint.py
@@ -73,6 +73,10 @@ def engage_yahoo():
 def engage_sbi():
     return flask.render_template("engage/sbi.html")
 
+@jp_website.route("/engage/robotics_whitepaper")
+def engage_robotics():
+    return flask.render_template("engage/robotics_whitepaper.html")
+
 
 @jp_website.route("/favicon.ico")
 def favicon():

--- a/webapp/blueprint.py
+++ b/webapp/blueprint.py
@@ -73,6 +73,7 @@ def engage_yahoo():
 def engage_sbi():
     return flask.render_template("engage/sbi.html")
 
+
 @jp_website.route("/engage/robotics_whitepaper")
 def engage_robotics():
     return flask.render_template("engage/robotics_whitepaper.html")


### PR DESCRIPTION
## Done

**blocked until we get the [PDF](https://github.com/canonical-web-and-design/web-squad/issues/1817)**
- Added robotics takeover and engage page

## QA

- Check out this branch
- `./run` the project
- Visit http://0.0.0.0:8012/ and refresh the page until you see a takeover with the heading "適切なロボットOSの選択"
- See that it matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1818#issuecomment-549411652) and the [brief](https://docs.google.com/spreadsheets/d/1-t6Lz_1sMnToPL8bdd_7alz9CTZyWlqcZ8E8YJq2BAo/edit#gid=2113339190)
- Follow the CTA to the engage page
- See that the engage page matches the [copy doc](https://docs.google.com/document/d/1VRn5RtLJ8qQwSWgGuAiLb_cLt_gSmClYtLY2QXMAsZo/edit)
- Validate the engage page on https://cards-dev.twitter.com/validator

## Issue / Card

Fixes #178 
