### PR TITLE
Update takeover template. Add 20.04 takeover

### DIFF
--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -1,0 +1,88 @@
+/// homepage takeovers
+
+@mixin p-takeovers($name) {
+  .p-takeover--#{$name} {
+    @extend %vf-strip;
+
+    background-blend-mode: multiply, multiply, normal, normal;
+    @content;
+
+    background-position: top right, top left, right bottom -1px, left top;
+    background-repeat: no-repeat;
+    background-size: 74% 99.83%, 68% 91%, 103.8% 20.26%, 100% 99.8%;
+    margin: 0;
+    padding-bottom: 11rem;
+    padding-top: 6rem;
+
+    @media (max-width: $breakpoint-medium) {
+      background-position: top right, top left, right bottom -1px, left top;
+      background-repeat: no-repeat;
+      background-size: 135% 97.83%, 148% 83%, 119% 13%, 100% 99.83%;
+      padding-bottom: 8rem;
+      padding-top: 4rem;
+    }
+
+    h1 {
+      padding-top: 0;
+    }
+
+    p:last-of-type {
+      margin-bottom: 0 !important;
+    }
+
+    .u-align--left-medium {
+      @media (max-width: $breakpoint-medium) {
+        justify-content: left !important;
+        padding: $spv-inner--scaleable 0 ($spv-inner--scaleable * 2) 0;
+        text-align: left !important;
+      }
+    }
+  }
+}
+
+@mixin jp-p-takeovers {
+  @include p-takeovers('grad') {
+    background-color: #772953;
+    background-image: linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0, rgba(119, 41, 83, 0.16) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(228, 228, 228, 0.5) 0, rgba(228, 228, 228, 0.5) 49.9%, transparent 50%), linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
+
+    @supports not (background-blend-mode: multiply) {
+      background-image: linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0, rgba(119, 41, 83, 0.16) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(228, 228, 228, 0.1) 0, rgba(228, 228, 228, 0.1) 49.9%, transparent 50%), linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
+    }
+
+    color: $color-x-light;
+  }
+
+  @include p-takeovers('k8s') {
+    background-color: #326de6;
+    background-image: linear-gradient(to bottom left, rgba(21, 58, 138, 0.16) 0, rgba(21, 58, 138, 0.16) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(50, 109, 230, 0.5) 0, rgba(50, 109, 230, 0.5) 49.9%, transparent 50%), linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(74deg, #173d8b 0%, #326de6 92%);
+
+    @supports not (background-blend-mode: multiply) {
+      background-image: linear-gradient(to bottom left, rgba(21, 58, 138, 0.16) 0, rgba(21, 58, 138, 0.16) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(50, 109, 230, 0.1) 0, rgba(50, 109, 230, 0.1) 49.9%, transparent 50%), linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(74deg, #173d8b 0%, #326de6 92%);
+    }
+
+    color: $color-x-light;
+  }
+
+  @include p-takeovers('dark') {
+    background-color: #111;
+    background-image: linear-gradient(to bottom left, rgba(216, 216, 216, 0.54) 0, rgba(216, 216, 216, 0.54) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(228, 228, 228, 0.54) 0, rgba(228, 228, 228, 0.54) 49.9%, transparent 50%), linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(201deg, #4e4e4e 0%, #333 46%, #111 90%);
+
+    @supports not (background-blend-mode: multiply) {
+      background-image: linear-gradient(to bottom left, rgba(216, 216, 216, 0.14) 0, rgba(216, 216, 216, 0.14) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(228, 228, 228, 0.14) 0, rgba(228, 228, 228, 0.14) 49.9%, transparent 50%), linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(201deg, #4e4e4e 0%, #333 46%, #111 90%);
+    }
+
+    color: $color-x-light;
+  }
+
+  @include p-takeovers('snapcraft') {
+    background-color: #83bfa1;
+    background-image: linear-gradient(to bottom left, rgba(74, 131, 125, 0.16) 0, rgba(74, 131, 125, 0.16) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(63, 120, 115, 0.08) 0, rgba(63, 120, 115, 0.08) 49.9%, transparent 50%), linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(134deg, #2d6162 0%, #83bfa1 100%);
+    color: $color-x-light;
+  }
+
+  @include p-takeovers('aqua') {
+    background-color: #2b585d;
+    background-image: linear-gradient(to bottom left, rgba(71, 145, 154, 0.16) 0, rgba(71, 145, 154, 0.16) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(71, 145, 154, 0.16) 0, rgba(71, 145, 154, 0.16) 49.9%, transparent 50%), linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(246deg, #47919a 0%, #47919a 53%, #2b585d 100%);
+    color: $color-x-light;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -16,6 +16,7 @@
 @import 'patterns_blog-post';
 @import 'patterns_blog-card';
 @import 'utility_crop';
+@import "pattern_takeovers";
 
 @include blog-p-list;
 @include blog-p-post;
@@ -29,6 +30,7 @@
 @include jp-p-pull-quotes;
 @include jp-p-table;
 @include jp-p-inline-images;
+@include jp-p-takeovers;
 
 // Remove all max widths on headings
 .u-align--center h1,

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,38 +7,11 @@
 {% block outer_content %}
   <!-- Section 1: Hero -->
   <template id="takeovers" class="u-hide">
-    {% include "takeovers/_sbi-takeover.html" %}
-    {% include "takeovers/_yahoo-takeover.html" %}
-    {% include "takeovers/_openstack-made-easy-takeover.html" %}
-    {% include "takeovers/_robotics-takeover.html" %}
+
   </template>
 
   <!-- Default Takeover: Download the latest Ubuntu -->
-  <section data-lang="all" id="takeover" class="p-strip--image js-takeover is-dark p-takeover--yahoo" >
-    <div class="row u-vertically-center">
-      <div class="col-8 u-fade-left--medium">
-        <h1>Yahoo! JAPAN、Canonicalとプライベートクラウドの構築で協業</h1>
-        <p class="u-no-padding--top p-heading--four">Yahoo! JAPANが、MAASとJujuを使用して2万VM用のOpenStackと1PBのCephストレージを3リージョンに展開した事例を紹介</p>
-        <a href="/engage/yahoo" class="p-button--positive">ユーザー事例をダウンロードする</a>
-      </div>
-      <div class="col-4 u-hide--small u-align--center u-vertically-center" >
-        <img src="https://assets.ubuntu.com/v1/a0e557b6-Yahoo-Japan.png" alt="Yahoo on Ubuntu by Canonical">
-      </div>
-    </div>
-    <style>
-      .p-takeover--yahoo {
-        background-image: url(https://assets.ubuntu.com/v1/e6a2c401-suru-left.svg), url(https://assets.ubuntu.com/v1/a9dab044-suru-right.svg), linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
-        background-position: left, right;
-        background-repeat: no-repeat, no-repeat;
-        background-size: auto 100%, auto 100%, cover;
-      }
-      @media (max-width: 874px) {
-        .p-takeover--yahoo {
-          background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
-        }
-      }
-    </style>
-  </section>
+  {% include "takeovers/_20.04.html" %}
 
   <section class="p-strip--image u-align--center is-bordered" style="background-image: url('https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/06a0285e-image-background-paper.png')">
     <div class="row">

--- a/templates/takeovers/_20.04.html
+++ b/templates/takeovers/_20.04.html
@@ -1,0 +1,16 @@
+{% with title="Ubuntu 20.04 LTS の新機能とは？",
+subtitle="20.04がセキュアなクラウド、エッジ処理、デスクトップのための新しいリファレンスプラットフォームである理由をご紹介します。",
+class="",
+header_image="https://assets.ubuntu.com/v1/6d623607-Focal+Fossa_orange_RGB.svg",
+image_style="",
+image_height="290",
+image_width="380",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/download",
+primary_cta="Ubuntuを入手する",
+primary_cta_class="",
+lang="jp",
+locale="" %}
+{% include "takeovers/shared/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/shared/_template.html
+++ b/templates/takeovers/shared/_template.html
@@ -1,0 +1,58 @@
+<section {% if lang %}lang="{{ lang }}"{% endif %} data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if class %}{{ class }}{% else %}p-takeover--grad{% endif %} js-takeover">
+  <div class="row u-equal-height">
+    <div class="{% if equal_cols %}col-6{% else %}col-7{% endif %} u-vertically-center">
+      <div>
+        <h1>
+          {{ title | safe }}
+        </h1>
+        {% if subtitle %}<h4>
+          {{ subtitle | safe }}
+        </h4>{% endif %}
+        <div class="u-hide--small">
+          {% if primary_url %}
+          <p>
+            <a href="{{ primary_url }}" class="{% if primary_cta_class %}{{ primary_cta_class }}{% else %}p-button--positive{% endif %} u-no-margin--bottom">{% if 'http' in primary_url %}<span class="p-link--external">{% endif %}{{ primary_cta }}{% if 'http' in primary_url %}</span>{% endif %}
+            </a>
+          </p>
+          {% endif %}
+          {% if secondary_url %}
+          <p>
+            <a href="{{ secondary_url }}" class="{% if 'http' in secondary_url %}p-link--external{% endif %} p-link--inverted">
+              {{ secondary_cta }}{% if 'http' not in secondary_url %}&nbsp;&rsaquo;{% endif %}
+            </a>
+          </p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    {% if header_image %}
+    <div class="{% if equal_cols %}col-6{% else %}col-5{% endif %} {% if image_hide_small is sameas true %}u-hide--small{% endif %} u-vertically-center u-align--center u-align--left-medium">
+      {% if image_width and image_height %}
+        {% if 'http' not in header_image %}
+          {% set image_url = "https://assets.ubuntu.com/v1/" + header_image %}
+        {% else %}
+          {% set image_url = header_image %}
+        {% endif %}
+        <img src="{{ image_url }}" alt="" height="{{ image_height }}" width="{{ image_width }}" loading="auto" {% if image_style %}style="{{ image_style }}"{% endif %}>
+      {% else %}
+        <img src="{% if 'http' not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" alt="" {% if image_style %}style="{{ image_style }}"{% endif %}>
+      {% endif %}
+    </div>
+    {% endif %}
+    <div class="u-hide--medium u-hide--large">
+      {% if primary_url %}
+      <p>
+        <a href="{{ primary_url }}" class="{% if primary_cta_class %}{{ primary_cta_class }}{% else %}p-button--positive{% endif %}">{% if 'http' in primary_url %}<span class="p-link--external">{% endif %}{{ primary_cta }}{% if 'http' in primary_url %}</span>{% endif %}
+        </a>
+      </p>
+      {% endif %}
+      {% if secondary_url %}
+      <p>
+        <a href="{{ secondary_url }}" class="{% if 'http' in secondary_url %}p-link--external{% endif %} p-link--inverted">
+          {{ secondary_cta }}{% if 'http' not in secondary_url %}&nbsp;&rsaquo;{% endif %}
+        </a>
+      </p>
+      {% endif %}
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done

Added the 20.04 takeover to the homepage

## QA

- ./run
- Visit http://localhost:8012
- Check that the takeover looks good, links to downloads and uses the [correct copy](https://github.com/canonical-web-and-design/ubuntu.com/issues/7184#issuecomment-618333390)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7184