### PR TITLE
Add a /download/thank-you page

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -44,7 +44,7 @@
       <h3 class="p-card__title">Ubuntu Desktop {{ releases.lts.full_version }} LTS</h3>
       <div class="p-card__content">
         <p>デスクトップPCおよびノートPC向けUbuntu LTS版の最新バージョンをダウンロードいただけます。LTSはlong-term support（長期サポート）の略称です。{{ releases.lts.eol }}年 4 月までの5 年間、無料のセキュリティアップデートおよびメンテナンスアップデートが保証されています。</p>
-        <p><a class="p-button--positive row" href="https://ubuntu.com/download/desktop/thank-you?version={{ releases.lts.full_version }}&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       </div>
     </div>
@@ -53,7 +53,7 @@
       <h3 class="p-card__title">Ubuntu Desktop {{ releases.latest.full_version }}</h3>
       <div class="p-card__content">
         <p>デスクトップPCおよびノートPC向けのUbuntuオペレーティングシステムの最新バージョンです。Ubuntu {{ releases.lts.full_version }} では、2020年7月までの9か月間、セキュリティアップデートおよびメンテナンスアップデートが提供されます</p>
-        <p><a class="p-button--neutral row" href="https://ubuntu.com/download/desktop/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-button--neutral row" href="/download/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
       </div>
     </div>
@@ -85,7 +85,7 @@
       <h3 class="p-card__title">Ubuntu Server {{ releases.lts.full_version }} LTS</h3>
       <div class="p-card__content">
         <p>Ubuntu ServerのLTS版には、OpenStackの{{ releases.openstack_lts.slug }}リリースが含まれ、{{ releases.lts.eol }}年4月までのサポートが保証されています。64ビット版のみの提供です。</p>
-        <p><a class="p-button--positive row" href="https://ubuntu.com/download/server/thank-you?version={{ releases.lts.full_version }}&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version }}&architecture=amd64&platform=live-server"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       </div>
     </div>
@@ -94,7 +94,7 @@
       <h3 class="p-card__title">Ubuntu Server {{ releases.latest.full_version }}</h3>
       <div class="p-card__content">
         <p>Ubuntu Serverの最新バージョンです。2020年7月までの9か月のセキュリティアップデートとメンテナンスアップデートが含まれます。</p>
-        <p><a class="p-button--neutral row" href="https://ubuntu.com/download/server/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-button--neutral row" href="/download/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64&platform=live-server"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
       </div>
     </div>

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -1,0 +1,153 @@
+{% extends "_base/base.html" %}
+{% set active_page = "download" %}
+
+{% block title %}Ubuntu のダウンロードありがとうございます | Ubuntu{% endblock title %}
+
+{% block meta_description %}Ubuntuは、スマートフォン、タブレット端末、PCからサーバー、クラウドまであらゆる環境で動作するオープンソースのソフトウェアプラットフォームです。{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/12zeiOqbYg_dxSBwwm4Z4rHJje9A0LBQZyiOMaOOaRd0/edit#heading=h.gjdgxs{% endblock meta_copydoc %}
+
+{% block head_extra %}
+<meta name="robots" content="noindex" />
+<meta http-equiv="refresh" content="3;url=http://jp.releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-{{ platform }}-{{ architecture }}.iso">
+{% endblock head_extra %}
+
+{% block outer_content %}
+<section class="p-strip--light is-deep is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h1>
+        Ubuntu のダウンロードありがとうございます
+      </h1>
+      <p>
+        ダウンロードは自動的に開始します。開始しない場合は、<a href="http://jp.releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-{{ platform }}-{{ architecture }}.iso">こちらをクリックしてください</a>。
+      </p>
+      <p>
+        ダウンロードを確認するか、<a class="p-link--external" href="{% if platform == 'live-server' %}https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server{% else %}https://ubuntu.com/tutorials/tutorial-install-ubuntu-desktop{% endif %}">インストールに関するヘルプ</a>をご覧ください。
+      </p>
+    </div>
+  </div>
+</section>
+
+
+{# subscribe to newsletter
+{% if platform == 'live-server' %}
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2>Ubuntu ウィークリーニュースを購読</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>
+        Ubuntu Serverに関する最新情報を毎週お届けします：
+      </p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">セキュリティ情報</li>
+        <li class="p-list__item is-ticked">リリース発表</li>
+        <li class="p-list__item is-ticked">一般的な技術情報</li>
+        <li class="p-list__item is-ticked">アドバイスやチュートリアル</li>
+      </ul>
+      <h4>
+        コマンドラインの復習が必要ですか？
+      </h4>
+      <p>
+        ご購読の方には「2019年版Ubuntu Serverのコマンドラインに関するアドバイス」もお届けします。
+      </p>
+      <p>
+        基本的なファイル管理からKubernetesやOpenStackの導入まで、コマンドライン早見表でDevOpsを始めましょう。
+      </p>
+      <img class="u-hide--small" src="https://assets.ubuntu.com/v1/39a8dac8-Ubuntu_Server_CLI_pro_tips_2020-04.jpg" width="440" height="331" alt="">
+    </div>
+    <div class="col-6">
+      <!-- insert form -->
+    </div>
+  </div>
+</section>
+{% endif %}
+#}
+
+{# other resources #}
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2>その他のドキュメンテーションとリソース</h2>
+  </div>
+  <div class="row p-divider">
+    <div class="row p-divider">
+      <div class="col-4 p-divider__block">
+        <h4>
+          <a class="p-link--external" href="{% if platform == 'live-server' %}https://ubuntu.com/server/docs{% else %}https://help.ubuntu.com/{% endif %}">
+            Ubuntu ガイド
+          </a>
+        </h4>
+        <p>
+          コミュニティとUbuntu開発者が集めたUbuntuに関する資料です。
+        </p>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h4>
+          <a class="p-link--external" href="https://askubuntu.com/">
+            Ask Ubuntu
+          </a>
+        </h4>
+        <p>
+          行き詰まったときは、ベテランユーザーが疑問を解いてくれます。
+        </p>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h4>
+          <a class="p-link--external" href="https://discourse.ubuntu.com/">
+            コミュニティハブ
+          </a>
+        </h4>
+        <p>
+          Ubuntu開発者コミュニティのディスカッションに参加し、皆さんの声を伝えましょう。
+        </p>
+      </div>
+    </div>
+  </section>
+
+
+  {# support #}
+  <section class="p-strip--light">
+    <div class="row">
+      <div class="col-8">
+        <h2>
+          本番環境でUbuntuを使用していますか？
+        </h2>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">電話およびチケットによるサポート</li>
+          <li class="p-list__item is-ticked">ライブパッチによるカーネル更新</li>
+          <li class="p-list__item is-ticked">KubernetesとOpenStackのサポート</li>
+          <li class="p-list__item is-ticked">LTSリリースのセキュリティメンテナンス延長</li>
+        </ul>
+        <p>
+          Ubuntu Advantage for Infrastructureのサブスクリプションですべてお届けします。
+        </p>
+        <p class="u-sv3">
+          <a class="p-button--positive" href="https://buy.ubuntu.com">
+            詳細はこちら
+          </a>
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-8">
+        <h2>
+          高度な活用
+        </h2>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">
+            <a class="p-link--external" href="https://maas.io/">
+              MAASを利用した物理サーバーで大規模にUbuntu Serverを運用
+            </a>
+          </li>
+          <li class="p-list__item is-ticked">
+            <a class="p-link--external" href="https://landscape.canonical.com">
+              LandscapeでUbuntuインスタンスすべてを管理/監視
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+  {% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4,6 +4,7 @@ A Flask application for jp.ubuntu.com
 
 # Packages
 import yaml
+import flask
 from canonicalwebteam.blog import BlogViews
 from canonicalwebteam.blog.flask import build_blueprint
 from canonicalwebteam.flask_base.app import FlaskBase
@@ -37,6 +38,9 @@ def context():
         "replace_admin": template_utils.replace_admin,
         "truncate_chars": template_utils.truncate_chars,
         "releases": releases,
+        "platform": flask.request.args.get("platform", ""),
+        "version": flask.request.args.get("version", ""),
+        "architecture": flask.request.args.get("architecture", ""),
     }
 
 

--- a/webapp/blueprint.py
+++ b/webapp/blueprint.py
@@ -46,7 +46,12 @@ def pricing():
 
 @jp_website.route("/download")
 def download():
-    return flask.render_template("download.html")
+    return flask.render_template("download/index.html")
+
+
+@jp_website.route("/download/thank-you")
+def download_thank_you():
+    return flask.render_template("download/thank-you.html")
 
 
 @jp_website.route("/contact-us")


### PR DESCRIPTION
## Done

- Created a download thank you page for desktop and server
- **NOTE** the server cli cheat sheet and marketo form are not ready, but this could go live as is

## QA

1. Download and run this branch
2. Go to:
    - http://0.0.0.0:8012/download/thank-you?version=20.04&architecture=amd64&platform=live-server
    - http://0.0.0.0:8012/download/thank-you?version=20.04&architecture=amd64&platform=desktop
3. See that it downloads a desktop or server from jp.releases.ubuntu.com
3. compare to the [copy doc](https://docs.google.com/document/d/12zeiOqbYg_dxSBwwm4Z4rHJje9A0LBQZyiOMaOOaRd0/edit#)

## Issue / Card

Fixes #219 

