### PR TITLE
Add cli and newsletter form to the /download/thank-you page

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -5,7 +5,7 @@
 
   <div class="blog-p-card__content">
     <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_3649" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-      <h3 class="p-card--title p-heading--four">Ubuntu ウィークリーニュースを購読</h3>
+      <h3 class="p-card--title p-heading--four">Ubuntuニュースレターを購読</h3>
 
       <div class="mktFormReq mktField">
         <label>
@@ -25,7 +25,7 @@
       </div>
 
       <p>
-        <small>このフォームを送信する際に、私が読んで同意することを確認します<a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonicalのプライバシーに関するお知らせ</a>そして<a href="https://ubuntu.com/legal/data-privacy">個人情報保護方針。</a></small>
+        <small>お客様が購読登録を行われる場合、以下の条件に同意されたことになります。<a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonicalのプライバシーに関するお知らせ</a><a href="https://ubuntu.com/legal/data-privacy">個人情報保護ポリシー</a></small>
       </p>
 
       <div>

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -30,14 +30,13 @@
 </section>
 
 
-{# subscribe to newsletter
 {% if platform == 'live-server' %}
 <section class="p-strip is-bordered">
   <div class="row">
     <h2>Ubuntu ウィークリーニュースを購読</h2>
   </div>
   <div class="row">
-    <div class="col-6">
+    <div class="col-7">
       <p>
         Ubuntu Serverに関する最新情報を毎週お届けします：
       </p>
@@ -56,15 +55,60 @@
       <p>
         基本的なファイル管理からKubernetesやOpenStackの導入まで、コマンドライン早見表でDevOpsを始めましょう。
       </p>
-      <img class="u-hide--small" src="https://assets.ubuntu.com/v1/39a8dac8-Ubuntu_Server_CLI_pro_tips_2020-04.jpg" width="440" height="331" alt="">
+      <img class="u-hide--small" src="https://assets.ubuntu.com/v1/eee38fdf-JP_Ubuntu-Server-CLI-pro-tips.png" width="440" height="310" alt="">
     </div>
-    <div class="col-6">
+    <div class="col-5">
       <!-- insert form -->
+      <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_3649" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+        <h3 class="p-card--title p-heading--four">Ubuntu ウィークリーニュースを購読</h3>
+
+        <div class="mktFormReq mktField">
+          <label>
+            <span class="u-no-margin--top">メールアドレス:<span>*</span></span>
+            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+          </label>
+        </div>
+
+        <div class="mktField mktLblRight">
+          <span class="mktInput mktLblRight">
+            <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
+            <label for="CanonicalUpdatesOptIn" class="p-form__label u-no-margin--top">
+              <small>Canonicalの製品とサービスに関する情報を受け取ることに同意します。</small>
+            </label>
+            <span class="mktFormMsg"></span>
+          </span>
+        </div>
+
+        <p>
+          <small>このフォームを送信する際に、私が読んで同意することを確認します<a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonicalのプライバシーに関するお知らせ</a>そして<a href="https://ubuntu.com/legal/data-privacy">個人情報保護方針。</a></small>
+        </p>
+
+        <div>
+          <span class="mktoButtonWrap p-card--content">
+            <button type="submit" class="u-no-margin--bottom">送信</button>
+          </span>
+
+          <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+          <input type="hidden" name="cNblogsubscription" value="true" />
+
+          <input value="3649" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+          <input value="3649" class="mktoField mktoFieldDescriptor" name="formVid" type="hidden">
+          <input type="hidden" name="ret" value="{{request.base_url}}?newsletter=true" />
+          <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
+          <input name="kw" value="" type="hidden">
+          <input name="cr" value="" type="hidden">
+          <input name="searchstr" value="" type="hidden">
+          <input name="_mkt_disp" value="return" type="hidden">
+          <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
+          <input type="hidden" name="thankyoumessage" value="登録ありがとうございます。<br><a href='https://assets.ubuntu.com/v1/f401c3f4-Ubuntu_Server_CLI_pro_tips_2020-04.pdf' target='_blank' >これがCLIチートシートです。</a>">
+        </div>
+      </form>
+      <div class="js-feedback-notification"></div>
     </div>
   </div>
 </section>
 {% endif %}
-#}
+
 
 {# other resources #}
 <section class="p-strip is-bordered">
@@ -150,4 +194,19 @@
       </div>
     </div>
   </section>
+
+  <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
+  <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+  <script>
+    $("#mktoForm_3649").validate({
+      errorPlacement: function(error, element) {
+        error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
+        error.appendTo( element.addClass( "p-form-validation__input" ));
+      },
+      errorElement: "span",
+      errorClass: "p-form-validation__message"
+    });
+  </script>
+  <script src="{{ versioned_static('js/dist/forms.js') }}"></script>
+
   {% endblock %}

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -5,7 +5,7 @@
 
 {% block meta_description %}Ubuntuは、スマートフォン、タブレット端末、PCからサーバー、クラウドまであらゆる環境で動作するオープンソースのソフトウェアプラットフォームです。{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/12zeiOqbYg_dxSBwwm4Z4rHJje9A0LBQZyiOMaOOaRd0/edit#heading=h.gjdgxs{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/12zeiOqbYg_dxSBwwm4Z4rHJje9A0LBQZyiOMaOOaRd0/edit{% endblock meta_copydoc %}
 
 {% block head_extra %}
 <meta name="robots" content="noindex" />
@@ -33,7 +33,7 @@
 {% if platform == 'live-server' %}
 <section class="p-strip is-bordered">
   <div class="row">
-    <h2>Ubuntu ウィークリーニュースを購読</h2>
+    <h2>Ubuntuニュースレターを購読</h2>
   </div>
   <div class="row">
     <div class="col-7">
@@ -60,7 +60,7 @@
     <div class="col-5">
       <!-- insert form -->
       <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_3649" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-        <h3 class="p-card--title p-heading--four">Ubuntu ウィークリーニュースを購読</h3>
+        <h3 class="p-card--title p-heading--four">Ubuntuニュースレターを購読</h3>
 
         <div class="mktFormReq mktField">
           <label>
@@ -80,7 +80,7 @@
         </div>
 
         <p>
-          <small>このフォームを送信する際に、私が読んで同意することを確認します<a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonicalのプライバシーに関するお知らせ</a>そして<a href="https://ubuntu.com/legal/data-privacy">個人情報保護方針。</a></small>
+          <small>お客様が購読登録を行われる場合、以下の条件に同意されたことになります。<a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonicalのプライバシーに関するお知らせ</a><a href="https://ubuntu.com/legal/data-privacy">個人情報保護ポリシー</a></small>
         </p>
 
         <div>


### PR DESCRIPTION
## Done

Add cli and newsletter form to the /download/thank-you page

## QA

1. Download this branch
2. `dotrun` and go to http://0.0.0.0:8012/download/thank-you?version=20.04&architecture=amd64&platform=live-server
3. fill in the form and see the notification with the cli pdf linked

## Issue / Card

Fixes #220

![image](https://user-images.githubusercontent.com/441217/88897626-84bf6900-d243-11ea-88d6-ce8b57427fff.png)

