### PR TITLE
Create the CloudNative Days Tokyo 2020 page

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint-js": "eslint static/js",
     "test-python": "python3 -m unittest discover tests",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/css/modules static/js/modules",
+    "watch": "yarn run watch-css && yarn run watch-js",
     "watch-js": "watch -p 'static/js/**/*.js' -p 'static/js/third-party/**/*.js' -c 'webpack --env.development'",
     "watch-css": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
@@ -39,6 +40,6 @@
   },
   "dependencies": {
     "@canonical/global-nav": "2.4.3",
-    "vanilla-framework": "2.15.0"
+    "vanilla-framework": "2.17.0"
   }
 }

--- a/static/sass/_settings_colors.scss
+++ b/static/sass/_settings_colors.scss
@@ -5,3 +5,6 @@ $color-accent: $color-brand;
 $color-accent-background: #2c001e;
 $color-navigation-background: #333;
 $color-navigation-active-bar: #e95420;
+$color-suru-start: $color-accent-background;
+$color-suru-middle: #6e2843;
+$color-suru-end: $color-brand;

--- a/templates/cloudnativedasytokyo2020.html
+++ b/templates/cloudnativedasytokyo2020.html
@@ -1,0 +1,199 @@
+{% extends "_base/base.html" %}
+{% set active_page = "" %}
+
+{% block title %}CloudNative Days Tokyo 2020 - クラウドからエッジまでのKubernetes | Ubuntu{% endblock %}
+
+{% block meta_description %}CNDTのCanonical & Ubuntuバーチャルブースでは、技術担当者と話せる121本のチャット、20.04 Ubuntuリリース記念Tシャツプレゼント、マルチクラウドKubernetesのライブデモなどをご用意して皆様をお待ちしています。クラウドでもエッジでも、テレコムでもロボットでも、CanonicalはKubernetesとMicroK8sの2種類のKubernetesディストリビューションであらゆる用途に対応いたします。詳細はチームまでお問い合わせください。{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1KdT9rlYyhCkDcsIGcrSaPKlo1yawZrTt1otHv3WlFSU/edit#{% endblock meta_copydoc %}
+
+{% block outer_content %}
+<section class="p-strip--suru">
+  <div class="row">
+    <div class="col-8">
+      <h1>CloudNative Days Tokyo 2020でUbuntuに注目</h1>
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2>ライブデモを見る</h2>
+  </div>
+  <div class="row">
+    <div class="u-sv3 u-embedded-media">
+      <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/live_stream?channel=UCJ65UG_WgFa_O_odbiBWZoA" frameborder="0" allowfullscreen></iframe>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <p>Kubernetesについてフィールドエンジニアにご相談ください</p>
+      <p>
+        <a href="" class="p-button--positive" onclick="LC_API.open_chat_window();return false">非公開Livechat</a>
+        <a href="/contact-us" class="p-button--neutral">お問い合わせ</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>MicroK8s：軽量、zero-ops、アップストリームのK8s</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block u-align--center">
+      <a href="https://www.brighttalk.com/webcast/6793/378029" aria-hidden="true" tabindex="-1">
+        <img src="https://assets.ubuntu.com/v1/acf10174-kubeconeu2020-intro-microk8s.png" alt=""/>
+      </a>
+      <p><a href="https://www.brighttalk.com/webcast/6793/378029">MicroK8sの概要</a></p>
+    </div>
+    <div class="col-4 p-divider__block u-align--center">
+      <a href="https://www.youtube.com/watch?v=xuq0waih5nA" aria-hidden="true" tabindex="-1">
+        <img src="https://assets.ubuntu.com/v1/f99533f8-kubeconeu2020-getting-started-microk8s.png" alt="" />
+      </a>
+      <p><a href="https://www.youtube.com/watch?v=xuq0waih5nA">MicroK8sを使ってみる - 技術的な基本事項</a></p>
+    </div>
+    <div class="col-4 p-divider__block u-align--center">
+      <a href="http://microk8s.io" aria-hidden="true" tabindex="-1">
+        <img src="https://assets.ubuntu.com/v1/b8a85a31-MicroK8s_SnapStore_icon.png" alt="" style="max-height: 181px;" />
+      </a>
+      <p><a href="http://microk8s.io">Linux、Mac、WindowsでのKubernetes簡単インストール</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>マルチクラウドKubernetes：クラウドからエッジまで…ベアメタルからパブリッククラウドまで</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block u-align--center">
+      <a href="https://www.brighttalk.com/webcast/6793/421884" aria-hidden="true" tabindex="-1">
+        <img src="https://assets.ubuntu.com/v1/975708ea-1596114051.png" alt="" />
+      </a>
+      <p><a href="https://www.brighttalk.com/webcast/6793/421884">クラウドからエッジまでのKubernetes</a></p>
+    </div>
+    <div class="col-4 p-divider__block u-align--center">
+      <a href="https://www.brighttalk.com/webcast/6793/362200" aria-hidden="true" tabindex="-1">
+        <img src="https://assets.ubuntu.com/v1/e7bec2a3-1562776783.png" alt="" />
+      </a>
+      <p><a href="https://www.brighttalk.com/webcast/6793/362200">エッジで利用するKubernetes</a></p>
+    </div>
+    <div class="col-4 p-divider__block u-align--center">
+      <a href="https://ubuntu.com/kubernetes" aria-hidden="true" tabindex="-1">
+        <img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" style="max-height: 195px;" />
+      </a>
+      <p><a href="https://ubuntu.com/kubernetes">UbuntuでのKubernetes</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Kubeflow：AI（人工知能）/ ML（機械学習）をワークステーションから本番環境まで</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block u-align--center">
+      <a href="https://ubuntu.com/blog/ai-ml-model-ubuntu" aria-hidden="true" tabindex="-1">
+        <img src="https://ubuntu.com/wp-content/uploads/c12a/AI-Webinar1080p.png" alt="" />
+      </a>
+      <p><a href="https://ubuntu.com/blog/ai-ml-model-ubuntu">Ubuntuで初めてのAI/MLモデルを構築</a></p>
+    </div>
+    <div class="col-4 p-divider__block u-align--center">
+      <a href="https://www.brighttalk.com/webcast/6793/424551" aria-hidden="true" tabindex="-1">
+        <img src="https://assets.ubuntu.com/v1/5154b93b-1595351903.png" alt="" />
+      </a>
+      <p><a href="https://www.brighttalk.com/webcast/6793/424551">Kubeflowパイプラインの謎を解く</a></p>
+    </div>
+    <div class="col-4 p-divider__block u-align--center">
+      <a href="https://ubuntu.com/kubeflow/install" aria-hidden="true" tabindex="-1">
+        <img src="https://assets.ubuntu.com/v1/6ff815e5-Kubeflow-Logo-RGB.svg" alt="" style="max-height: 195px;" />
+      </a>
+      <p><a href="https://ubuntu.com/kubeflow/install">どこでもKubeflowをインストール</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip" id="enter">
+  <div class="row">
+    <div class="col-7">
+      <h2>Ubuntu 20.04 LTS Focal Fossa限定Tシャツが当たる</h2>
+      <img src="https://assets.ubuntu.com/v1/4c6176c2-FocalFossa--t-shirt-black-removebg-preview.png" alt="Focal Fossa t-shirt in black">
+    </div>
+    <div class="col-5" id="the-form">
+      <!-- MARKETO FORM -->
+      <script src="//assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
+      <script  src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+      <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>‌​
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_3702">
+        <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+          <ul class="p-list">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel">名:</label>
+              <input required="" id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="First Name" style="background-image: url(&quot;data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABHklEQVQ4EaVTO26DQBD1ohQWaS2lg9JybZ+AK7hNwx2oIoVf4UPQ0Lj1FdKktevIpel8AKNUkDcWMxpgSaIEaTVv3sx7uztiTdu2s/98DywOw3Dued4Who/M2aIx5lZV1aEsy0+qiwHELyi+Ytl0PQ69SxAxkWIA4RMRTdNsKE59juMcuZd6xIAFeZ6fGCdJ8kY4y7KAuTRNGd7jyEBXsdOPE3a0QGPsniOnnYMO67LgSQN9T41F2QGrQRRFCwyzoIF2qyBuKKbcOgPXdVeY9rMWgNsjf9ccYesJhk3f5dYT1HX9gR0LLQR30TnjkUEcx2uIuS4RnI+aj6sJR0AM8AaumPaM/rRehyWhXqbFAA9kh3/8/NvHxAYGAsZ/il8IalkCLBfNVAAAAABJRU5ErkJggg==&quot;); background-repeat: no-repeat; background-attachment: scroll; background-size: 16px 18px; background-position: 98% 50%; cursor: auto;">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="LastName" class="mktoLabel ">姓:</label>
+              <input required="" id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Last Name">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Email" class="mktoLabel ">ビジネスメール:</label>
+              <input required="" id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" aria-label="Email">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Company" class="mktoLabel ">会社名:</label>
+              <input required="" id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Title" class="mktoLabel ">職名:</label>
+              <input required="" id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Phone" class="mktoLabel ">電話番号:</label>
+              <input required="" id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel" aria-label="Phone Number">
+            </li>
+            <li class="mktField">
+              <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="" type="hidden">
+            </li>
+            <li class="mktField">
+              <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="" type="hidden">
+            </li>
+            <li class="mktField">
+              <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="" type="hidden">
+            </li>
+            <li class="mktField">
+              <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">Canonical の製品やサービスについての情報を受け取ることに同意します。</label>
+            </li>
+            <li class="mktField">
+              <p> 私は、このフォームの送信により、本プレゼントへの応募において応募規約、<a href="https://assets.ubuntu.com/v1/dbd44952-CloudNative+Days+Tokyo+Raffle+2020+-+Terms+and+Conditions+.pdf">規約と条件</a>, <a href="https://ubuntu.com/legal/data-privacy/contact">Canonicalのプライバシーポリシー</a>、<a href="https://ubuntu.com/legal/data-privacy">Canonicalのプライバシーについての通知</a>を順守し、受諾することに同意します。
+                <input name="RichText" aria-label="RichText" type="hidden">
+              </p>
+            </li>
+            <li class="mktField">
+              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;" data-widget-id="0"><div style="width: 304px; height: 78px;"><div><iframe src="https://www.google.com/recaptcha/api2/anchor?ar=1&amp;k=6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if&amp;co=aHR0cHM6Ly91YnVudHUuY29tOjQ0Mw..&amp;hl=en-GB&amp;v=NjbyeWjjFy97MXGZ40KrXu3v&amp;size=normal&amp;cb=wm4adnyu4fge" role="presentation" name="a-jdjmhduasyyf" scrolling="no" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals allow-popups-to-escape-sandbox allow-storage-access-by-user-activation" width="304" height="78" frameborder="0"></iframe></div><textarea id="g-recaptcha-response" name="g-recaptcha-response" class="g-recaptcha-response" style="width: 250px; height: 40px; border: 1px solid rgb(193, 193, 193); margin: 10px 25px; padding: 0px; resize: none; display: none;"></textarea></div><iframe style="display: none;"></iframe></div>
+            </li>
+            <li class="mktField">
+              <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+            </li>
+            <li class="mktField">
+              <button type="submit" class="mktoButton u-no-margin--bottom">参加する</button>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335">
+              <input name="formid" aria-label="formid" class="mktoField" value="3702" type="hidden">
+              <input name="formVid" aria-label="formid" class="mktoField" value="3702" type="hidden">
+              <input type="hidden" name="returnURL" aria-label="returnURL" value="https://jp.ubuntu.com/thank-you">
+              <input type="hidden" name="retURL" aria-label="retURL" value="https://jp.ubuntu.com/thank-you">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="https://jp.ubuntu.com/thank-you">
+            </li>
+          </ul>
+        </fieldset>
+      </form>
+      <!-- /MARKETO FORM -->
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/cloudnativedasytokyo2020.html
+++ b/templates/cloudnativedasytokyo2020.html
@@ -15,7 +15,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip is-bordered">
+<section class="p-strip">
   <div class="row">
     <h2>ライブデモを見る</h2>
   </div>
@@ -35,7 +35,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-8">
       <h2>MicroK8s：軽量、zero-ops、アップストリームのK8s</h2>
@@ -63,7 +63,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>マルチクラウドKubernetes：クラウドからエッジまで…ベアメタルからパブリッククラウドまで</h2>
@@ -91,7 +91,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-8">
       <h2>Kubeflow：AI（人工知能）/ ML（機械学習）をワークステーションから本番環境まで</h2>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -26,22 +26,6 @@ class TestRoutes(unittest.TestCase):
 
         self.assertEqual(self.client.get("/iot").status_code, 200)
 
-    def test_blog(self):
-        """
-        When given the blog URL,
-        we should return a 200 status code
-        """
-
-        self.assertEqual(self.client.get("/blog").status_code, 200)
-
-    def test_openstack(self):
-        """
-        When given the openstack URL,
-        we should return a 200 status code
-        """
-
-        self.assertEqual(self.client.get("/openstack").status_code, 200)
-
     def test_iot(self):
         """
         When given the iot URL,
@@ -66,16 +50,6 @@ class TestRoutes(unittest.TestCase):
 
         self.assertEqual(self.client.get("/kubernetes").status_code, 200)
 
-    def test_enterprise_support(self):
-        """
-        When given the enterprise-support URL,
-        we should return a 200 status code
-        """
-
-        self.assertEqual(
-            self.client.get("/enterprise-support").status_code, 200
-        )
-
     def test_pricing(self):
         """
         When given the pricing URL,
@@ -83,14 +57,6 @@ class TestRoutes(unittest.TestCase):
         """
 
         self.assertEqual(self.client.get("/pricing").status_code, 200)
-
-    def test_download(self):
-        """
-        When given the download URL,
-        we should return a 200 status code
-        """
-
-        self.assertEqual(self.client.get("/download").status_code, 200)
 
     def test_contact_us(self):
         """

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -34,6 +34,16 @@ with open("releases.yaml") as releases:
     releases = yaml.load(releases, Loader=yaml.FullLoader)
 
 
+@app.errorhandler(404)
+def not_found_error(error):
+    return flask.render_template("404.html"), 404
+
+
+@app.errorhandler(500)
+def internal_error(error):
+    return flask.render_template("500.html"), 500
+
+
 # Template context
 @app.context_processor
 def context():

--- a/webapp/blueprint.py
+++ b/webapp/blueprint.py
@@ -29,6 +29,11 @@ def ai_ml():
     return flask.render_template("ai-ml.html")
 
 
+@jp_website.route("/cloudnativedasytokyo2020")
+def cloudnativedasytokyo2020():
+    return flask.render_template("cloudnativedasytokyo2020.html")
+
+
 @jp_website.route("/kubernetes")
 def k8s():
     return flask.render_template("kubernetes.html")

--- a/yarn.lock
+++ b/yarn.lock
@@ -8244,10 +8244,10 @@ vanilla-framework@2.13.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.13.0.tgz#ac73e745150bcef183eb35e3ee47f3fd079ddd3e"
   integrity sha512-EuxlGxO4SmCGL4GVzcye5aas2HGVqRhPxlTHg84Lfw1e1E4F/Coxs78i3xxkPGw3LOcfea0KU096ar1PnLNuXQ==
 
-vanilla-framework@2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.15.0.tgz#be22c92cda0a22108daa35eb76d096add0cebbe7"
-  integrity sha512-PrNwDwAHUCVnJQz0hIufFm5GHpeDds+uiK9GHtXD/mgyDoFeQLrARSqIb9cA0FtYqoCOw3vJPmk1HD08eKTNnA==
+vanilla-framework@2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.17.0.tgz#e33f072b34e98f98ab611e8292ba9277216adeb9"
+  integrity sha512-Zqn0UVcvKjffO16ajSidzOwlZAcIJFOZu2LsK0IWDiZGFdlCe/iQZH0tcM6M5repcbDPi93I9Thv4kpfPMAeqg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done
Create the CloudNative Days Tokyo 2020 page

Drive-bys:
- Update Vanilla to the latest version
- Add the `watch` script to get `./run watch` to work
- Added routes to the error pages

## QA
- Open the demo
- Go to /cloudnativedasytokyo2020
- Check it matches the design in [the brief](https://docs.google.com/document/d/1DvtZtxdTSqbDeP_Y-N0O7wf11KcVwWJP8vrVpXX_qew/edit?ts=5f55e291#heading=h.nespdl5ahi02)
- Check the content matches the [copy doc](https://docs.google.com/document/d/10DG5YnFFEoFTAlM3g2fo5mTtCyI6UXKKDfDSEuGGzvQ/edit)
- Check the form works and goes to the thank you

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8118

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/92401801-4f514980-f126-11ea-89dc-ff98043a2d99.png)

