### PR TITLE
Build pepabo engage page

### DIFF
--- a/templates/engage/case-study-gmo-pepabo.html
+++ b/templates/engage/case-study-gmo-pepabo.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}GMOペパボがカーネルのライブパッチによって運用コストと2,500時間の手作業を削減{% endblock %}
 
-{% block meta_image %}{% endblock %}
+{% block meta_image %}https://assets.ubuntu.com/v1/a17c5c1a-90651366-d51f5a80-e234-11ea-88fa-a817d1d1e959.jpg{% endblock %}
 
 {% block outer_content %}
 

--- a/templates/engage/case-study-gmo-pepabo.html
+++ b/templates/engage/case-study-gmo-pepabo.html
@@ -35,7 +35,7 @@
     </div>
     <div class="col-5" id="register-section">
       <h3>ダウンロード</h3>
-      {% with  id="3589", returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/GMO Pepabo Case study 8.pdf" %}
+      {% with  id="3589", returnURL="https://assets.ubuntu.com/v1/63e7fc75-JP_GMO+Pepabo+Case+study.pdf" %}
         {% include "engage/shared/_form.html"%}
       {% endwith %}
     </div>

--- a/templates/engage/case-study-gmo-pepabo.html
+++ b/templates/engage/case-study-gmo-pepabo.html
@@ -1,0 +1,44 @@
+{% extends "_base/base.html" %}
+
+{% block title %}GMOペパボについて{% endblock %}
+
+{% block meta_description %}GMOペパボがカーネルのライブパッチによって運用コストと2,500時間の手作業を削減{% endblock %}
+
+{% block meta_image %}{% endblock %}
+
+{% block outer_content %}
+
+{% with  title="GMOペパボがカーネルのライブパッチによって運用コストと2,500時間の手作業を削減",  image="https://assets.ubuntu.com/v1/bab3a999-GMO+Pepabo-ubuntu_white.svg", url="#register-section", cta="ケーススタディをダウンロード", class="p-takeover--dark" %}
+  {% include "engage/shared/_header.html" %}
+{% endwith %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>ウェブホスティング会社のGMOペパボは、ドメイン登録、ウェブホスティング、eコマースのサポート、ハンドメイドグッズのC2C（Customer to Customer、顧客間）販売などのインターネットサービスを消費者向けに提供しています。多くの会社がこのサービスに依存しているため、GMOペパボにとって業務を担うワークロードの停止は許容できません。</p>
+
+      <p>GMOペパボは約80台の物理サーバーでUbuntu 16.04 LTSを実行し、Canonicalから無料セキュリティ更新の定期的な配布を受けています。これらのパッチがシステムの潜在的な脆弱性を修正していますが、重要なカーネル更新を適用するには一般にサーバーの再起動が必要です。カーネルのセキュリティ修正のためにマシンを再起動するには、ワークロードを移行する必要があり、多くの人手が必要です。GMOペパボは、時間とコストを節約するプロセスが必要だと認識していました。</p>
+
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">Livepatchは当社のニーズにぴったりです。このようなソリューションは他にありませんし、費用対効果も優れています。</p>
+        <cite class="p-pull-quote__citation">— GMOペパボ、技術部シニアエンジニアリングリード、常松伸哉氏</cite>
+      </blockquote>
+
+      <p>結果として、GMOペパボはサーバーの再起動なしに最新のカーネル更新やセキュリティ修正を自動的に適用するため、CanonicalのUbuntu Advantage for Infrastructureの一部であるLivepatchを採用しました。パッチ処理はマイクロ秒単位で完了し、継続中のワークロードは中断しません。</p>
+
+      <p>ケーススタディをダウンロードして、詳細をご覧ください。</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Livepatchの採用により、サーバーへのパッチ適用の際、手作業によるワークロードの移行が不要に</li>
+        <li class="p-list__item is-ticked">ESMがUbuntu 16.04 LTSのサポート終了後もセキュリティを確保</li>
+        <li class="p-list__item is-ticked">GMOペパボは、小規模のデータセンターとサーバーでKubernetesを活用できるMicroK8sも検討</li>
+      </ul>
+    </div>
+    <div class="col-5" id="register-section">
+      <h3>ダウンロード</h3>
+      {% with  id="3589", returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/GMO Pepabo Case study 8.pdf" %}
+        {% include "engage/shared/_form.html"%}
+      {% endwith %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/engage/case-study-gmo-pepabo.html
+++ b/templates/engage/case-study-gmo-pepabo.html
@@ -35,7 +35,7 @@
     </div>
     <div class="col-5" id="register-section">
       <h3>ダウンロード</h3>
-      {% with  id="3589", returnURL="https://assets.ubuntu.com/v1/63e7fc75-JP_GMO+Pepabo+Case+study.pdf" %}
+      {% with  id="3589", returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/JP_GMO%2BPepabo%2BCase%2Bstudy.pdf" %}
         {% include "engage/shared/_form.html"%}
       {% endwith %}
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -92,7 +92,7 @@
     </div>
   </section>
 
-  <section class="p-strip">
+  <section class="p-strip is-bordered">
     <div class="row u-vertically-center">
       <div class="col-7 u-align--center">
         <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/11da76f5-image-management.svg" alt="" class="u-hide--small"  style="height: 120%">
@@ -100,6 +100,18 @@
       <div class="col-5">
         <h3><a href="/enterprise-support">エンタープライズ向けLinuxの<br class="u-hide--small u-hide--medium" />安定運用&nbsp;&rsaquo;</a></h3>
         <p>Canonicalは、Ubuntu、OpenStack、Docker、Kubernetesに対して24時間体制のエンタープライズ向けサポート、セキュリティ、故障時補償を提供<br class="u-hide--small u-hide--medium" />します。</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-deep is-bordered">
+    <div class="row u-equal-height u-vertically-center">
+      <div class="col-6">
+        <h3><a href="/engage/case-study-gmo-pepabo">GMOペパボについて&nbsp;&rsaquo;</a></h3>
+        <p>GMOペパボがカーネルのライブパッチによって運用コストと2,500時間の手作業を削減</p>
+      </div>
+      <div class="col-6 u-align--centre">
+        <img src="https://pepabo.com/assets/images/site_name-en.svg" class="u-hide--small">
       </div>
     </div>
   </section>

--- a/webapp/blueprint.py
+++ b/webapp/blueprint.py
@@ -94,6 +94,11 @@ def engage_cyberdyne():
     return flask.render_template("engage/cyberdyne.html")
 
 
+@jp_website.route("/engage/case-study-gmo-pepabo")
+def engage_pepabo():
+    return flask.render_template("engage/case-study-gmo-pepabo.html")
+
+
 @jp_website.route("/favicon.ico")
 def favicon():
     return flask.redirect(


### PR DESCRIPTION
## Done

- Build engage page at `/engage/case-study-gmo-pepabo`
- Add to `/engage/index.html`
- Create [social banner](https://assets.ubuntu.com/v1/528cf2ab-facebook_and_linkedin_banner+%283%29.jpeg) 

## QA

- Check out this feature branch
- Run the site using the command ./run serve or dotrun
- View the site locally in your web browser at: [http://0.0.0.0:8012/engage](http://0.0.0.0:8012/engage) to check GMO pepabo added and check engage page at [http://0.0.0.0:8012/engage/case-study-gmo-pepabo](http://0.0.0.0:8012/engage/case-study-gmo-pepabo) matches [copy doc](https://docs.google.com/document/d/1TewivXyiRIQyz8m4IXg1o1gC7nsZAxrfcrB32szE8jI/edit#) and [design](https://github.com/canonical-web-and-design/web-squad/issues/3055)

## Issue / Card

Fixes [#8363](https://github.com/canonical-web-and-design/ubuntu.com/issues/8363)

