### PR TITLE
Add cookie-policy v3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@babel/core": "7.11.6",
     "@babel/preset-env": "7.11.5",
+    "@canonical/cookie-policy": "3.0.3",
     "autoprefixer": "10.0.1",
     "babel-jest": "26.5.2",
     "babel-loader": "8.1.0",

--- a/static/js/cookie-policy.js
+++ b/static/js/cookie-policy.js
@@ -1,0 +1,3 @@
+import { cookiePolicy } from "@canonical/cookie-policy";
+
+cookiePolicy();

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,22 +1,25 @@
-@import 'settings_general';
-@import 'settings_colors';
-@import 'settings_animations';
-@import 'vanilla-framework/scss/build';
+@import "settings_general";
+@import "settings_colors";
+@import "settings_animations";
+@import "vanilla-framework/scss/build";
 
 // Local patterns
-@import 'pattern_cloud-tools';
-@import 'pattern_hero';
-@import 'pattern_contextual-footer';
-@import 'pattern_navigation';
-@import 'pattern_pie-chart';
-@import 'pattern_pull-quotes';
-@import 'pattern_table';
-@import 'pattern_inline-images';
-@import 'patterns_blog-list';
-@import 'patterns_blog-post';
-@import 'patterns_blog-card';
-@import 'utility_crop';
+@import "pattern_cloud-tools";
+@import "pattern_hero";
+@import "pattern_contextual-footer";
+@import "pattern_navigation";
+@import "pattern_pie-chart";
+@import "pattern_pull-quotes";
+@import "pattern_table";
+@import "pattern_inline-images";
+@import "patterns_blog-list";
+@import "patterns_blog-post";
+@import "patterns_blog-card";
+@import "utility_crop";
 @import "pattern_takeovers";
+
+// import cookie policy
+@import "@canonical/cookie-policy/build/css/cookie-policy";
 
 @include blog-p-list;
 @include blog-p-post;
@@ -47,7 +50,7 @@
 // XXX KW 2019-01-11 Fix for strip borders
 // Fix is already in Vanilla master so this can be removed when upgraing to Vanilla 2.0
 
-[class^='p-strip'] {
+[class^="p-strip"] {
   position: relative;
 
   &.is-bordered {
@@ -111,5 +114,5 @@
   }
 
   // use google nato font for japanese chars
-  @import url('//fonts.googleapis.com/css?family=Noto+Sans+JP:300,400,500.css&subset=japanese'); // sass-lint:disable-line no-url-protocols no-url-domains
+  @import url("//fonts.googleapis.com/css?family=Noto+Sans+JP:300,400,500.css&subset=japanese"); // sass-lint:disable-line no-url-protocols no-url-domains
 }

--- a/templates/_base/footer.html
+++ b/templates/_base/footer.html
@@ -11,6 +11,9 @@
         <li class="p-inline-list__item">
           <a class="p-link--soft" href="https://github.com/canonical-websites/jp.ubuntu.com/issues/new" id="report-a-bug">Report a bug on this site</a>
         </li>
+        <li class="p-inline-list__item">
+          <a class="p-link--soft js-revoke-cookie-manager" href="">Manage your tracker settings</a>
+        </li>
       </ul>
 
       <script>

--- a/templates/_base/footer.html
+++ b/templates/_base/footer.html
@@ -27,5 +27,6 @@
 </section>
 
 <script src="{{versioned_static('js/dist/global-nav.js')}}" defer></script>
+<script src="{{versioned_static('js/dist/cookie-policy.js')}}" defer></script>
 
 {% endblock footer %}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -1,4 +1,5 @@
 module.exports = {
+  ["cookie-policy"]: "./static/js/cookie-policy.js",
   ["latest-news"]: "./static/js/latest-news.js",
   ["global-nav"]: "./static/js/global-nav.js",
   ["forms"]: ["./static/js/forms.js", "./static/js/form-validation.js"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,6 +1167,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@canonical/cookie-policy@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.3.tgz#77ff09de8cc91c3bd12d23bfeaaf23a0206995ad"
+  integrity sha512-cTNrBAO+w5Akrn32Arkp/YGgT9KXTUuCMAgE8ipABBtkEIQ2Z708mTkZ3FNgefxPvMuDuLCVvKhvHik31SEShg==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done
Add cookie-policy v3.0.3

**Do not merge until @pmahnke has done the GTM changes**

## QA
- Load the demo and you should see the cookie policy
- Open the manager and select something
- See it is gone
- Click the link in the footer to manage cookies
- See it opens again without errors in the console.

## Issue / Card
Fixes #248
