### PR TITLE
Build GMO Pepabo takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
   <template id="takeovers" class="u-hide">
     {% include "takeovers/_cyberdyne.html" %}
     {% include "takeovers/_20.04.html" %}
+    {% include "takeovers/_gmo-pepabo-takeover.html"%}
   </template>
 
   <!-- Default Takeover: Download the latest Ubuntu -->

--- a/templates/takeovers/_gmo-pepabo-takeover.html
+++ b/templates/takeovers/_gmo-pepabo-takeover.html
@@ -1,0 +1,14 @@
+{% with title="GMOペパボがカーネルのライブパッチによって運用コストと2,500時間の手作業を削減",
+subtitle="",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/c92b1d48-GMO-Pepabo-ubuntu_white.svg",
+image_style="",
+image_height="250",
+image_width="250",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/engage/case-study-gmo-pepabo?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_JP_CStudy_GMOPepabo",
+primary_cta="ケーススタディをダウンロード",
+primary_cta_class="" %}
+{% include "takeovers/shared/_template.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done

- Build GMO Pepabo takeover 
- Add to `index.html` 

## QA

- Check out this feature branch
- Run the site using the command ./run serve
- View the site locally in your web browser at: http://0.0.0.0:8012 and refresh until you see pepabo takeover
- Check CTA links to http://0.0.0.0:8012/engage/case-study-gmo-pepabo


## Issue / Card

[#3277](https://github.com/canonical-web-and-design/web-squad/issues/3277)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/95475801-8497c400-097e-11eb-977d-f07b7ee9cfe2.png)
