### PR TITLE
20.10 release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,9 +1,9 @@
 latest:
-  slug: EoanErmine
-  short_version: "19.10"
-  full_version: "19.10"
-  release_date: "October 2019"
-  eol: 2020
+  slug: GroovyGorilla
+  short_version: "20.10"
+  full_version: "20.10"
+  release_date: "October 2020"
+  eol: 2021
 lts:
   slug: FocalFossa
   short_version: "20.04"
@@ -17,10 +17,12 @@ previous_lts:
   full_version: "18.04.5"
 checksums:
   desktop:
+    "20.10": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.10-desktop-amd64.iso"
     "20.04.1": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.04.1-desktop-amd64.iso"
     "19.10": "96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso"
     "18.04.5": "f295570badb09a606d97ddfc3421d7bf210b4a81c07ba81e9c040eda6ddea6a0 *ubuntu-18.04.5-desktop-amd64.iso"
   live-server:
+    "20.10": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.10-live-server-amd64.iso"
     "20.04.1": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.04.1-live-server-amd64.iso"
     "19.10": "3fe242f4b330ead8191b3c200bcf1d8d3be4243d62fe6b866a778499370c9dbb *ubuntu-19.10-live-server-amd64.iso"
     "18.04.5": "3756b3201007a88da35ee0957fbe6666c495fb3d8ef2e851ed2bd1115dc36446 *ubuntu-18.04.5-live-server-amd64.iso"

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -52,7 +52,7 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title">Ubuntu Desktop {{ releases.latest.full_version }}</h3>
       <div class="p-card__content">
-        <p>デスクトップPCおよびノートPC向けのUbuntuオペレーティングシステムの最新バージョンです。Ubuntu {{ releases.lts.full_version }} では、2020年7月までの9か月間、セキュリティアップデートおよびメンテナンスアップデートが提供されます</p>
+        <p>デスクトップPCおよびノートPC向けのUbuntuオペレーティングシステムの最新バージョンです。Ubuntu {{ releases.latest.full_version }} では、{{ releases.latest.eol }}年7月までの9か月間、セキュリティアップデートおよびメンテナンスアップデートが提供されます</p>
         <p><a class="p-button--neutral row" href="/download/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
     {% include "takeovers/_20.04.html" %}
   </section>
 
-  <section class="p-strip--image u-align--center is-bordered" style="background-image: url('https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/06a0285e-image-background-paper.png')">
+  <section class="p-strip u-align--center is-bordered">
     <div class="row">
       <div class="col-start-large-2 col-10">
         <p class="p-heading--four">


### PR DESCRIPTION
## Done
- Remove image strip to make takeover strip always compatible
- Update the releases.yaml for 20.10 release
- Make the latest download content dynamic

## QA
- Go to the demo
- Check the hero on the homepage blends nicely into the second strip
- Go to /download
- Check there is a Ubuntu Desktop 20.10 card
- Check the content and button is correct.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/jp.ubuntu.com/issues/259

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/96701754-daaa3580-1388-11eb-80ed-5ed20c53c27f.png)

