### PR TITLE
Add Redhat Engage page and Takeover

### DIFF
--- a/templates/engage/redhat-openstack-whitepaper.html
+++ b/templates/engage/redhat-openstack-whitepaper.html
@@ -1,0 +1,41 @@
+
+{% extends "_base/base.html" %}
+
+{% block title %}Charmed OpenStackによる運用コストの低減、柔軟性の向上、使いやすさの改善 | Ubuntu{% endblock %}
+
+{% block meta_description %}Charmed OpenStackによる運用コストの低減、柔軟性の向上、使いやすさの改善{% endblock %}
+
+{% block meta_image %}https://assets.ubuntu.com/v1/3d6f5aa6-twitter_wide_banner+%283%29.jpeg{% endblock %}
+
+{% block outer_content %}
+
+{% with  title="Red Hat OpenStack PlatformとCanonicalのCharmed OpenStackとの比較",  image="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg", image_width="250", url="#register-section", cta="ホワイトペーパーをダウンロード", class="p-takeover--dark" %}
+  {% include "engage/shared/_header.html" %}
+{% endwith %}
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
+      <p>プライベートクラウドインフラストラクチャを使用する今日のすべての組織において、財務の改善、セキュリティの強化、柔軟性の増大のために、OpenStackは不可欠なコンポーネントです。Red HatとCanonicalはどちらも独自の実運用グレードのOpenStackディストリビューションを提供していますが、両社のOpenStack展開、運用、サポートに対する手法は完全に異なるものです。</p>
+
+      <p>このホワイトペーパーでは、Red Hat OpenStack Platformと、CanonicalのCharmed OpenStackについて、次のような詳細な比較を行います。</p>
+        
+      <ul class="p-list">
+        <li class="p-list__item">Red Hatのソケット単位の価格モデルと、Canonicalのホスト単位の価格モデルとを比較した、包括的なコスト分析</li>
+        <li class="p-list__item">OpenStackの展開、アップグレード、日常的な保守で利用可能なサポートと、管理されたサービスの詳細な比較</li>
+        <li class="p-list__item">それぞれのディストリビューションをハイブリッドまたはマルチクラウド環境で使用した場合の統合能力の概要</li>
+      </ul>
+    </div>
+    <div class="col-5" id="register-section">
+      <h3>ダウンロード</h3>
+      {% with 
+        id="3737", 
+        returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/JP_Comparing.OpenStack_05.11.20.pdf" 
+      %}
+        {% include "engage/shared/_form.html"%}
+      {% endwith %}
+    </div>
+  </div>
+</section>
+
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
   <!-- Section 1: Hero -->
   <template id="takeovers" class="u-hide">
     {% include "takeovers/_cyberdyne.html" %}
-    {% include "takeovers/_20.04.html" %}
+    {% include "takeovers/_redhat-openstack-comparison-whitepaper.html" %}
     {% include "takeovers/_gmo-pepabo-takeover.html"%}
   </template>
 

--- a/templates/takeovers/_redhat-openstack-comparison-whitepaper.html
+++ b/templates/takeovers/_redhat-openstack-comparison-whitepaper.html
@@ -1,0 +1,14 @@
+{% with title="Red Hat OpenStack PlatformとCanonicalのCharmed OpenStackとの比較",
+subtitle="Charmed OpenStackによりTCOを大幅に低減",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg",
+image_style="",
+image_height="250",
+image_width="300",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/engage/redhat-openstack-whitepaper?utm_source=takeover&utm_medium=takeover&utm_campaign=7013z000001Wl8Q",
+primary_cta="ホワイトペーパーをダウンロード",
+primary_cta_class="" %}
+{% include "takeovers/shared/_template.html" %}
+{% endwith %}

--- a/webapp/blueprint.py
+++ b/webapp/blueprint.py
@@ -99,6 +99,11 @@ def engage_pepabo():
     return flask.render_template("engage/case-study-gmo-pepabo.html")
 
 
+@jp_website.route("/engage/redhat-openstack-whitepaper")
+def engage_redhat():
+    return flask.render_template("engage/redhat-openstack-whitepaper.html")
+
+
 @jp_website.route("/favicon.ico")
 def favicon():
     return flask.redirect(


### PR DESCRIPTION
## Done

- Add engage page to `/engage/redhat-openstack-whitepaper`
- Build takeover at `/takeovers/_redhat-openstack-comparison-whitepaper`
- Add takeover to `index.html` replacing 20.04

## QA

- Check out this feature branch
- Run the site using the command ./run serve or dotrun
- View the site locally in your web browser at: http://0.0.0.0:8012/engage/redhat-openstack-whitepaper
- Check engage page and check takeover by refreshing homepage

## Issue / Card

Fixes [#8587](https://github.com/canonical-web-and-design/ubuntu.com/issues/8587)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/98278573-afcafe80-1f90-11eb-9324-f4d6ee093c1d.png)

