### PR TITLE
Build 20.10 takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,17 +5,20 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1J4zHHJ19ueONPtgj9oHTWGvWRX5JTmHy8VuGy4mygp8/edit{% endblock meta_copydoc %}
 
 {% block outer_content %}
+
+  <section id="takeover">
+    {% include "takeovers/_20.10.html" %}
+  </section>
   <!-- Section 1: Hero -->
   <template id="takeovers" class="u-hide">
+    {% include "takeovers/_20.10.html" %}
     {% include "takeovers/_cyberdyne.html" %}
     {% include "takeovers/_redhat-openstack-comparison-whitepaper.html" %}
     {% include "takeovers/_gmo-pepabo-takeover.html"%}
   </template>
 
   <!-- Default Takeover: Download the latest Ubuntu -->
-  <section id="takeover">
-    {% include "takeovers/_20.04.html" %}
-  </section>
+
 
   <section class="p-strip u-align--center is-bordered">
     <div class="row">

--- a/templates/takeovers/_20.10.html
+++ b/templates/takeovers/_20.10.html
@@ -1,0 +1,19 @@
+
+{% with title="Ubuntu 20.10の新機能とは？",
+subtitle="Raspberry Pi用のUbuntu Desktop、最新のデスクトップ機能を導入し、マイクロクラウドに対応します。",
+class="",
+header_image="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg",
+image_style="",
+image_height="388",
+image_width="250",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/download?utm_source=takwover&utm_medium=takeover",
+primary_cta="Ubuntu 20.10を入手する",
+primary_cta_class="",
+secondary_url="/blog/ubuntu-20-10%e3%82%92%e6%90%ad%e8%bc%89%e3%81%97%e3%81%9fraspberry-pi%e3%81%8c%e5%ae%8c%e5%85%a8%e3%81%aalinux%e3%83%87%e3%82%b9%e3%82%af%e3%83%88%e3%83%83%e3%83%97%e3%81%a8%e3%83%9e%e3%82%a4%e3%82%af",
+secondary_cta="もっと詳しく知る",
+lang="",
+locale="" %}
+{% include "takeovers/shared/_template.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done

- Build 20.10 takeover and add to `/index.html`

## QA

- Check out this feature branch
- Run the site using the command ./run serve or dotrun
- View the site locally in your web browser at: http://0.0.0.0:8012/
- Refresh the page to see the 20.10 takeover. Check against the [brief](https://docs.google.com/spreadsheets/d/1Tbz8fV0soTEbDYZxaGgN3zVhDdrRi61chsOmGd8i1uo/edit#gid=2113339190) and check the links. 

## Issue / Card

Fixes [#8693](https://github.com/canonical-web-and-design/ubuntu.com/issues/8693)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/98531088-bbac0e80-2277-11eb-8641-f244295fdeb2.png)
