### PR TITLE
Add facebook tracking to engage page forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "watch": "yarn run watch-css && yarn run watch-js",
     "watch-js": "watch -p 'static/js/**/*.js' -p 'static/js/third-party/**/*.js' -c 'webpack --env.development'",
     "watch-css": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
-    "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
+    "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' --no-map",
     "build-js": "mkdir -p static/dist && webpack",
     "build": "mkdir -p static/dist && webpack && yarn run build-css",
     "serve": "./entrypoint 0.0.0.0:$PORT",
@@ -35,7 +35,6 @@
     "stylelint": "13.7.2",
     "stylelint-config-standard": "20.0.0",
     "stylelint-order": "4.1.0",
-    "terser-webpack-plugin": "4.2.3",
     "watch-cli": "0.2.3",
     "webpack": "5.1.0",
     "webpack-cli": "4.0.0"

--- a/templates/engage/shared/_form.html
+++ b/templates/engage/shared/_form.html
@@ -1,59 +1,55 @@
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
       <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{id}}" class="marketo-form" style="margin-bottom: 2rem;" onSubmit="fbq('trackCustom', 'Download');">
-        <fieldset>
-          <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel ">姓</label> <!-- First name: -->
-              <input required="" id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" aria-required="true">
-            </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="LastName" class="mktoLabel">名</label> <!-- Last name: -->
-              <input required="" id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" aria-required="true">
-            </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="Email" class="mktoLabel">メールアドレス</label> <!-- Email address: -->
-              <input required="" id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" aria-required="true">
-            </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="Company" class="mktoLabel">会社名</label> <!-- Company name: -->
-              <input required="" id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" aria-required="true">
-            </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="Title" class="mktoLabel">役職</label> <!-- Job title: -->
-              <input required="" id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" aria-required="true">
-            </li>
-          </ul>
-        </fieldset>
+        <ul class="p-list">
+          <li class="mktFormReq mktField p-list__item">
+            <label for="FirstName" class="mktoLabel ">姓</label> <!-- First name: -->
+            <input required="" id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" aria-required="true">
+          </li>
+          <li class="mktFormReq mktField p-list__item">
+            <label for="LastName" class="mktoLabel">名</label> <!-- Last name: -->
+            <input required="" id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" aria-required="true">
+          </li>
+          <li class="mktFormReq mktField p-list__item">
+            <label for="Email" class="mktoLabel">メールアドレス</label> <!-- Email address: -->
+            <input required="" id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" aria-required="true">
+          </li>
+          <li class="mktFormReq mktField p-list__item">
+            <label for="Company" class="mktoLabel">会社名</label> <!-- Company name: -->
+            <input required="" id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" aria-required="true">
+          </li>
+          <li class="mktFormReq mktField p-list__item">
+            <label for="Title" class="mktoLabel">役職</label> <!-- Job title: -->
+            <input required="" id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" aria-required="true">
+          </li>
+        </ul>
 
-        <fieldset>
-          <ul class="p-list">
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">不定期配信のニュースメールを希望の方はこちらをチェックください。</label> <!-- I would like to receive occasional news from Canonical by email. -->
-            </li>
-            <li class="p-list__item">
-              <p><a href="https://ubuntu.com/legal" target="_blank">記載頂いた情報はCanonicalの個人情報保護ポリシーに基づき管理いたします。</a>.</p>
-            </li> <!-- All information provided will be handled in accordance with the Canonical privacy policy -->
-          </ul>
-          <ul class="p-list u-no-margin--bottom">
-            <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--positive">
+        <ul class="p-list">
+          <li class="mktField p-list__item">
+            <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+            <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">不定期配信のニュースメールを希望の方はこちらをチェックください。</label> <!-- I would like to receive occasional news from Canonical by email. -->
+          </li>
+          <li class="p-list__item">
+            <p><a href="https://ubuntu.com/legal" target="_blank">記載頂いた情報はCanonicalの個人情報保護ポリシーに基づき管理いたします。</a>.</p>
+          </li> <!-- All information provided will be handled in accordance with the Canonical privacy policy -->
+        </ul>
+        <ul class="p-list u-no-margin--bottom">
+          <li class="mktField p-list__item">
+            <button type="submit" class="mktoButton p-button--positive">
 ダウンロード
 </button>
-            </li> <!-- Submit -->
-          </ul>
-          <!-- hidden fields -->
-          <input type="hidden" name="formid" class="mktoField" value="{{id}}">
-          <input type="hidden" name="lpId" class="mktoField" value="">
-          <input type="hidden" name="subId" class="mktoField" value="">
-          <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
-          <input type="hidden" name="cr" class="mktoField" value="">
-          <input type="hidden" name="kw" class="mktoField" value="">
-          <input type="hidden" name="q" class="mktoField" value="">
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{returnURL}}" />
-        </fieldset>
+          </li> <!-- Submit -->
+        </ul>
+        <!-- hidden fields -->
+        <input type="hidden" name="formid" class="mktoField" value="{{id}}">
+        <input type="hidden" name="lpId" class="mktoField" value="">
+        <input type="hidden" name="subId" class="mktoField" value="">
+        <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
+        <input type="hidden" name="cr" class="mktoField" value="">
+        <input type="hidden" name="kw" class="mktoField" value="">
+        <input type="hidden" name="q" class="mktoField" value="">
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{returnURL}}" />
       </form>
 
 {% block footer_extra %}

--- a/templates/engage/shared/_form.html
+++ b/templates/engage/shared/_form.html
@@ -1,6 +1,6 @@
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{id}}" class="marketo-form" style="margin-bottom: 2rem;">
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{id}}" class="marketo-form" style="margin-bottom: 2rem;" onSubmit="fbq('trackCustom', 'Download');">
         <fieldset>
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
@@ -25,7 +25,7 @@
             </li>
           </ul>
         </fieldset>
-        
+
         <fieldset>
           <ul class="p-list">
             <li class="mktField p-list__item">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,18 +3,7 @@
 const entry = require("./webpack.config.entry.js");
 const rules = require("./webpack.config.rules.js");
 
-const TerserPlugin = require("terser-webpack-plugin");
-
 const production = process.env.ENVIRONMENT !== "devel";
-
-// turn on terser plugin on production
-const minimizer = production
-  ? [
-      new TerserPlugin({
-        sourceMap: true,
-      }),
-    ]
-  : [];
 
 module.exports = {
   entry: entry,
@@ -26,9 +15,5 @@ module.exports = {
   devtool: production ? "source-map" : "eval-source-map",
   module: {
     rules: rules,
-  },
-  optimization: {
-    minimize: true,
-    minimizer,
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8252,7 +8252,7 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@4.2.3, terser-webpack-plugin@^4.1.0:
+terser-webpack-plugin@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-4.2.3.tgz#28daef4a83bd17c1db0297070adc07fc8cfc6a9a"
   integrity sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==


### PR DESCRIPTION
## Done

- Add facebook tracking to engage page forms
- Remove terser

## QA

1. Download this branch
2. Go to http://0.0.0.0:8012/engage/case-study-gmo-pepabo
3. View the source and see that `onSubmit="fbq('trackCustom', 'Download');"` is on the form tag

## Issue / Card

Fixes #270