### PR TITLE
Add rigado case study engage page and takeover

### DIFF
--- a/templates/engage/rigado-casestudy.html
+++ b/templates/engage/rigado-casestudy.html
@@ -1,0 +1,61 @@
+{% extends "_base/base.html" %}
+
+{% block title %}Rigado、Ubuntu CoreとAWSにより商用IoT開発期間を最大1年間短縮{% endblock %}
+
+{% block meta_description %}急速に変化し続けるIoTの世界において、開発期間の短縮は至上課題です{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1AgntXrtRR-28SKCQ_qJ9XcB_-JeyPnluHbm_s3v6r-o/edit#{% endblock %}
+
+{% block meta_image %}https://assets.ubuntu.com/v1/c181f155-jp-rigado-case-study-meta.jpg{% endblock %}
+
+{% block outer_content %}
+
+{% with  title="Rigado、Ubuntu Core", subtitle="とAWSにより商用IoT開発期間を最大1年間短縮", image="https://assets.ubuntu.com/v1/1fbf2fe2-Rigado-gateway.svg", url="#register-section", cta="ホワイトペーパーをダウンロード", class="p-takeover--grad" %}
+  {% include "engage/shared/_header.html" %}
+{% endwith %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>
+        急速に変化し続けるIoTの世界において、開発期間の短縮は至上課題です。Rigadoの主な企業使命は、商用IoTを展開するための拡張性とセキュリティを備えたインフラストラクチャの提供です。
+      </p>
+
+      <p>
+        Rigadoが求めている使いやすさを達成するには、自社のゲートウェイソフトウェアの再設計が必要なことは明らかで、そのための最良の方法として浮かび上がったのがコンテナ化でした。Rigadoは多くのコンテナオプションを検討しましたが、それらのオプションには多くの可動部品が含まれていたことから、同社はUbuntu Coreとsnapの採用を決定しました。Ubuntu Coreへの切り替えにより、RigadoはUbuntu AMI（Amazon Machine Image）を活用して、UbuntuインスタンスをAWS内で迅速に開始できるようになりました。
+      </p>
+
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote u-sv1">
+          当社はビルドサーバーとして主にAMIを使用していますが、何かの目的ですぐにLinuxマシンが必要なときはEC2上のUbuntu AMIを起動します。これは簡単で確実です。当社は、CanonicalとAmazonが作成したパイプラインに信頼を置いています。
+        </p>
+        <cite class="p-pull-quote__citation">
+          — Rigado社CTO、Justin Rigling氏
+        </cite>
+      </blockquote>
+
+      <p>
+        ケーススタディをダウンロードして、詳細をご覧ください。
+      </p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          顧客がAWSとUbuntu Coreを使用して、市場か期間を最大で1年間も短縮するとともに総合的な環境を改善した方法
+
+        </li>
+        <li class="p-list__item is-ticked">
+          RigadoがCanonicalおよびAWSと協力して、Bluetoothベースの顧客データを自社のクラウドアプリケーションに簡単に搭載するためのメカニズムとなるAWS IoT Greengrassのsnapを開発した方法
+        </li>
+        <li class="p-list__item is-ticked">
+          Rigadoのゲートウェイは最短でも5年間現場で使用するよう設計されているため、Canonicalの長期的なサポートが重要であった理由
+        </li>
+      </ul>
+    </div>
+    <div class="col-5" id="register-section">
+      <h3>ダウンロード</h3>
+      {% with  id="3768", returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/JP_Rigado.Case.study.pdf" %}
+        {% include "engage/shared/_form.html"%}
+      {% endwith %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
   <!-- Section 1: Hero -->
   <template id="takeovers" class="u-hide">
     {% include "takeovers/_20.10.html" %}
+    {% include "takeovers/_rigado-takeover.html" %}
     {% include "takeovers/_cyberdyne.html" %}
     {% include "takeovers/_redhat-openstack-comparison-whitepaper.html" %}
     {% include "takeovers/_gmo-pepabo-takeover.html"%}

--- a/templates/takeovers/_rigado-takeover.html
+++ b/templates/takeovers/_rigado-takeover.html
@@ -1,0 +1,14 @@
+{% with title="Rigado、Ubuntu Core",
+subtitle="とAWSにより商用IoT開発期間を最大1年間短縮",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/1fbf2fe2-Rigado-gateway.svg",
+image_style="",
+image_height="150",
+image_width="400",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/engage/rigado-casestudy?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7014K000000gYVP",
+primary_cta="ホワイトペーパーをダウンロード",
+primary_cta_class="" %}
+{% include "takeovers/shared/_template.html" %}
+{% endwith %}

--- a/webapp/blueprint.py
+++ b/webapp/blueprint.py
@@ -94,6 +94,11 @@ def engage_cyberdyne():
     return flask.render_template("engage/cyberdyne.html")
 
 
+@jp_website.route("/engage/rigado-casestudy")
+def engage_rigado():
+    return flask.render_template("engage/rigado-casestudy.html")
+
+
 @jp_website.route("/engage/case-study-gmo-pepabo")
 def engage_pepabo():
     return flask.render_template("engage/case-study-gmo-pepabo.html")


### PR DESCRIPTION
## Done

- Add rigado case study engage page and takeover

## QA

1. download and run this branch
2. see the takeover on http://0.0.0.0:8012
3. go to the engage page for rigado - http://0.0.0.0:8012/engage/rigado-casestudy
4. compare it to the [brief](https://docs.google.com/spreadsheets/d/1yVWRHLfv4eA8JohIn6jjsdt8C_ZJO4OL7hXiRqUKtVs/edit#gid=1271849439) and the [copy doc](chrome-extension://klbibkeccnjlkjkiokjodocebajanakg/suspended.html#ttl=fin_Rigado%20Case%20Study%20-%20Landing%20Page%20-%20Google%20Docs&pos=0&uri=https://docs.google.com/document/d/1AgntXrtRR-28SKCQ_qJ9XcB_-JeyPnluHbm_s3v6r-o/edit#)

## Issue / Card

Fixes #272

## Screenshots
![image](https://user-images.githubusercontent.com/441217/100365174-0ad39c80-2ff7-11eb-91de-360ba440c2b0.png)

