### PR TITLE
Update to 20.04.2 on  /download

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -7,7 +7,7 @@ latest:
 lts:
   slug: FocalFossa
   short_version: "20.04"
-  full_version: "20.04.1"
+  full_version: "20.04.2"
   release_date: "April 2020"
   eol: 2025
 openstack_lts:
@@ -18,11 +18,11 @@ previous_lts:
 checksums:
   desktop:
     "20.10": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.10-desktop-amd64.iso"
-    "20.04.1": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.04.1-desktop-amd64.iso"
+    "20.04.2": "e2ce1771e352b04cfdef5bf6583f6a7d62b1f2967903fae512506d18d251a434 *ubuntu-20.04.2-desktop-amd64.iso"
     "19.10": "96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso"
     "18.04.5": "f295570badb09a606d97ddfc3421d7bf210b4a81c07ba81e9c040eda6ddea6a0 *ubuntu-18.04.5-desktop-amd64.iso"
   live-server:
     "20.10": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.10-live-server-amd64.iso"
-    "20.04.1": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.04.1-live-server-amd64.iso"
+    "20.04.2": "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423 *ubuntu-20.04.2-live-server-amd64.iso"
     "19.10": "3fe242f4b330ead8191b3c200bcf1d8d3be4243d62fe6b866a778499370c9dbb *ubuntu-19.10-live-server-amd64.iso"
     "18.04.5": "3756b3201007a88da35ee0957fbe6666c495fb3d8ef2e851ed2bd1115dc36446 *ubuntu-18.04.5-live-server-amd64.iso"


### PR DESCRIPTION
## Done

- Update to 20.04.2 on  /download

## QA

- look at http://0.0.0.0:8012/download
- see that it mentions 20.04.2 and links to these downloads

Fixes #289