### PR TITLE
Update desktop download to 20.04.2.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -19,7 +19,7 @@ previous_lts:
 checksums:
   desktop:
     "20.10": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.10-desktop-amd64.iso"
-    "20.04.2": "e2ce1771e352b04cfdef5bf6583f6a7d62b1f2967903fae512506d18d251a434 *ubuntu-20.04.2-desktop-amd64.iso"
+    "20.04.2.0": "93bdab204067321ff131f560879db46bee3b994bf24836bb78538640f689e58f *ubuntu-20.04.2.0-desktop-amd64.iso"
     "19.10": "96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso"
     "18.04.5": "f295570badb09a606d97ddfc3421d7bf210b4a81c07ba81e9c040eda6ddea6a0 *ubuntu-18.04.5-desktop-amd64.iso"
   live-server:

--- a/releases.yaml
+++ b/releases.yaml
@@ -8,6 +8,7 @@ lts:
   slug: FocalFossa
   short_version: "20.04"
   full_version: "20.04.2"
+  full_version_desktop: "20.04.2.0"
   release_date: "April 2020"
   eol: 2025
 openstack_lts:

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -41,10 +41,10 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <h3 class="p-card__title">Ubuntu Desktop {{ releases.lts.full_version }} LTS</h3>
+      <h3 class="p-card__title">Ubuntu Desktop {{ releases.lts.full_version_desktop }} LTS</h3>
       <div class="p-card__content">
         <p>デスクトップPCおよびノートPC向けUbuntu LTS版の最新バージョンをダウンロードいただけます。LTSはlong-term support（長期サポート）の略称です。{{ releases.lts.eol }}年 4 月までの5 年間、無料のセキュリティアップデートおよびメンテナンスアップデートが保証されています。</p>
-        <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version_desktop }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done
Update desktop download to 20.04.2.0

## QA
- Go to the demo
- Go to /downloads
- Check the title of the LTS is "20.04.3.0"
- Click download and ensure you get a download

## Issue / Card
Fixes https://github.com/canonical-web-and-design/jp.ubuntu.com/issues/292
