### PR TITLE
Initial update for 21.04 release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -31,16 +31,16 @@ previous_previous_lts:
 
 checksums:
   desktop:
-    "21.04": "XXXXX *ubuntu-21.04-desktop-amd64.iso"
+    "21.04": "fa95fb748b34d470a7cfa5e3c1c8fa1163e2dc340cd5a60f7ece9dc963ecdf88 *ubuntu-21.04-desktop-amd64.iso"
     "20.04.2.0": "93bdab204067321ff131f560879db46bee3b994bf24836bb78538640f689e58f *ubuntu-20.04.2.0-desktop-amd64.iso"
   live-server:
-    "21.04": "XXXXX *ubuntu-21.04-live-server-amd64.iso"
+    "21.04": "e4089c47104375b59951bad6c7b3ee5d9f6d80bfac4597e43a716bb8f5c1f3b0 *ubuntu-21.04-live-server-amd64.iso"
     "20.04.2": "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423 *ubuntu-20.04.2-live-server-amd64.iso"
   desktop-arm64+raspi:
-    "21.04": "XXXXX *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
+    "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
-    "21.04": "XXXXX *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz"
+    "21.04": "3df85b93b66ccd2d370c844568b37888de66c362eebae5204bf017f6f5875207 *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz"
     "20.04.2": "31884b07837099a5e819527af66848a9f4f92c1333e3ef0693d6d77af66d6832 *ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
-    "21.04": "XXXXX *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz"
+    "21.04": "c9a9a5177a03fcbb6203b38e5c3c4e5447fd9e8891515da4146f319f04eb3495 *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz"
     "20.04.2": "7b348d080648b8e36e1f29671afd973a0878503091b935b69828f2c7722dfb58 *ubuntu-20.04.2-preinstalled-server-armhf+raspi.img.xz"

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,29 +1,46 @@
 latest:
-  slug: GroovyGorilla
-  short_version: "20.10"
-  full_version: "20.10"
-  release_date: "October 2020"
-  eol: 2021
+  slug: HirsuteHippo
+  name: "Hirsute Hippo"
+  short_version: "21.04"
+  full_version: "21.04"
+  release_date: "April 2021"
+  eol: "January 2022"
+  past_eol_date: false
+  release_notes_url: "https://discourse.ubuntu.com/t/hirsute-hippo-release-notes/19221"
 lts:
   slug: FocalFossa
+  name: "Focal Fossa"
   short_version: "20.04"
   full_version: "20.04.2"
   full_version_desktop: "20.04.2.0"
   release_date: "April 2020"
-  eol: 2025
+  eol: "April 2025"
+  release_notes_url: "https://wiki.ubuntu.com/FocalFossa/ReleaseNotes"
 openstack_lts:
   slug: Ussuri
 previous_lts:
+  name: "Bionic Beaver"
   short_version: "18.04"
   full_version: "18.04.5"
+  release_date: "April 2018"
+  eol: "April 2023"
+previous_previous_lts:
+  name: "Xenial Xerus"
+  short_version: "16.04"
+  full_version: "16.04.7"
+
 checksums:
   desktop:
-    "20.10": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.10-desktop-amd64.iso"
+    "21.04": "XXXXX *ubuntu-21.04-desktop-amd64.iso"
     "20.04.2.0": "93bdab204067321ff131f560879db46bee3b994bf24836bb78538640f689e58f *ubuntu-20.04.2.0-desktop-amd64.iso"
-    "19.10": "96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso"
-    "18.04.5": "f295570badb09a606d97ddfc3421d7bf210b4a81c07ba81e9c040eda6ddea6a0 *ubuntu-18.04.5-desktop-amd64.iso"
   live-server:
-    "20.10": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.10-live-server-amd64.iso"
+    "21.04": "XXXXX *ubuntu-21.04-live-server-amd64.iso"
     "20.04.2": "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423 *ubuntu-20.04.2-live-server-amd64.iso"
-    "19.10": "3fe242f4b330ead8191b3c200bcf1d8d3be4243d62fe6b866a778499370c9dbb *ubuntu-19.10-live-server-amd64.iso"
-    "18.04.5": "3756b3201007a88da35ee0957fbe6666c495fb3d8ef2e851ed2bd1115dc36446 *ubuntu-18.04.5-live-server-amd64.iso"
+  desktop-arm64+raspi:
+    "21.04": "XXXXX *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
+  server-arm64+raspi:
+    "21.04": "XXXXX *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz"
+    "20.04.2": "31884b07837099a5e819527af66848a9f4f92c1333e3ef0693d6d77af66d6832 *ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz"
+  server-armhf+raspi:
+    "21.04": "XXXXX *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz"
+    "20.04.2": "7b348d080648b8e36e1f29671afd973a0878503091b935b69828f2c7722dfb58 *ubuntu-20.04.2-preinstalled-server-armhf+raspi.img.xz"

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -45,7 +45,7 @@
       <div class="p-card__content">
         <p>デスクトップPCおよびノートPC向けUbuntu LTS版の最新バージョンをダウンロードいただけます。LTSはlong-term support（長期サポート）の略称です。{{ releases.lts.eol }}年 4 月までの5 年間、無料のセキュリティアップデートおよびメンテナンスアップデートが保証されています。</p>
         <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version_desktop }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
-        <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
+        <p><a class="p-link--external" href="{{ releases.lts.release_notes_url }}">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       </div>
     </div>
     {% if releases.latest.short_version > releases.lts.short_version %}
@@ -54,7 +54,7 @@
       <div class="p-card__content">
         <p>デスクトップPCおよびノートPC向けのUbuntuオペレーティングシステムの最新バージョンです。Ubuntu {{ releases.latest.full_version }} では、{{ releases.latest.eol }}年7月までの9か月間、セキュリティアップデートおよびメンテナンスアップデートが提供されます</p>
         <p><a class="p-button--neutral row" href="/download/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
-        <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
+        <p><a class="p-link--external" href="{{ releases.latest.release_notes_url }}">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
       </div>
     </div>
     {% endif %}
@@ -86,7 +86,7 @@
       <div class="p-card__content">
         <p>Ubuntu ServerのLTS版には、OpenStackの{{ releases.openstack_lts.slug }}リリースが含まれ、{{ releases.lts.eol }}年4月までのサポートが保証されています。64ビット版のみの提供です。</p>
         <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version }}&architecture=amd64&platform=live-server"><span class="p-link--external">ダウンロード</span></a></p>
-        <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
+        <p><a class="p-link--external" href="{{ releases.lts.release_notes_url }}">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       </div>
     </div>
     {% if releases.latest.short_version > releases.lts.short_version %}
@@ -95,7 +95,7 @@
       <div class="p-card__content">
         <p>Ubuntu Serverの最新バージョンです。2020年7月までの9か月のセキュリティアップデートとメンテナンスアップデートが含まれます。</p>
         <p><a class="p-button--neutral row" href="/download/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64&platform=live-server"><span class="p-link--external">ダウンロード</span></a></p>
-        <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
+        <p><a class="p-link--external" href="{{ releases.latest.release_notes_url }}">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
## Done

- Updated the release.yaml to 21.04
- Updated the download page to use the new release.yaml release notes

## QA

- look at /download and see that it is ready for 21.04
- 
## Issue / Card

Fixes #308 

