### PR TITLE
Add form_id check for forms to show up correctly

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -80,7 +80,7 @@
       {{ text | safe }}
       {% endfor %}
     </div>
-    {% if document["metadata"]["form_id"] != "" %}
+    {% if "form_id" in document["metadata"] and document["metadata"]["form_id"] != "" %}
     <div class="col-5" id="the-form">
       {% if "form_cta" in document["metadata"] and document["metadata"]["form_cta"] != '' %}
         {% with id=document["metadata"]["form_id"], returnURL="https://jp.ubuntu.com" + document['metadata']['path']+"/thank-you", cta=document['metadata']['form_cta'] %}


### PR DESCRIPTION
## Done

Correction in the form check (if the `form_id` is not there do not show the form)
Correction of the root links for forms.

## QA

Check  https://jp-ubuntu-com-312.demos.haus/engage/yocto-buildroot-ubuntucore webinar does not show the form anymore.
Compare with curerent site https://jp.ubuntu.com/engage/yocto-buildroot-ubuntucore

## Issue / Card

Fixes #306 