### PR TITLE
Remove secondary url from default html if not in json

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
         <h4 id="takeover-subtitle">Raspberry Pi用のUbuntu Desktop、最新のデスクトップ機能を導入し、マイクロクラウドに対応します。</h4>
         <div id="takeover-ctas">
             <p>
-              <a id="takeover-primary-url" href="/download?utm_source=takwover&utm_medium=takeover" class="p-button--positive u-no-margin--bottom">
+              <a id="takeover-primary-url" href="/download?utm_source=takeover&utm_medium=takeover" class="p-button--positive u-no-margin--bottom">
                   <span>Ubuntu 20.10を入手する</span>
               </a>
             </p>
@@ -251,6 +251,8 @@
       if (selectedTakeover.secondary_url && selectedTakeover.secondary_url !== "") {
         secondaryUrl.href = selectedTakeover.secondary_url;
         secondaryUrl.innerHTML = selectedTakeover.secondary_cta + "&nbsp;&rsaquo;";
+      } else {
+          secondaryUrl.remove();
       }
     }
   </script>

--- a/templates/takeovers/_20.10.html
+++ b/templates/takeovers/_20.10.html
@@ -22,7 +22,7 @@ locale="" %}
           <h4>Raspberry Pi用のUbuntu Desktop、最新のデスクトップ機能を導入し、マイクロクラウドに対応します。</h4>
         <div class="u-hide--medium u-hide--large">
             <p>
-              <a href="/download?utm_source=takwover&utm_medium=takeover" class="p-button--positive u-no-margin--bottom">
+              <a href="/download?utm_source=takeover&utm_medium=takeover" class="p-button--positive u-no-margin--bottom">
                   <span>Ubuntu 20.10を入手する</span>
               </a>
             </p>


### PR DESCRIPTION
## Done

Remove the secondary cts html if it is in the default, but not in the takeovers.json

## QA

1. look at the live site and see that the takeovers both have the same seconary cta
2. look at the /takeovers.json and see that it doesn't have any seconary ctas
3. look at the demo and see they have been removed from the site

## Issue / Card

Fixes #324

## Screenshots

[before]
![image](https://user-images.githubusercontent.com/441217/120304539-c982b900-c2c7-11eb-8f67-a2af1d17ad05.png)


[after]
![image](https://user-images.githubusercontent.com/441217/120304499-bf60ba80-c2c7-11eb-86bf-94c346d688a0.png)


