### PR TITLE
Update node version to fix deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:12-slim AS yarn-dependencies
+FROM node:16 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install


### PR DESCRIPTION
## Done

[Jenkins job](https://jenkins.canonical.com/webteam/job/jp.ubuntu.com-staging/203/console) complaing that node-gyp can't find Python, so updating Node to v14 should fix this.

## QA

- Run image should pass, but this doesn't guarantee that deployement doesn't fail. As we seen before with `node-sass` issue

## Issue / Card

Fixes https://github.com/canonical-web-and-design/jp.ubuntu.com/issues/330