### PR TITLE
Bump the point release to 20.04.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -11,8 +11,7 @@ lts:
   slug: FocalFossa
   name: "Focal Fossa"
   short_version: "20.04"
-  full_version: "20.04.2"
-  full_version_desktop: "20.04.2.0"
+  full_version: "20.04.3"
   release_date: "April 2020"
   eol: "April 2025"
   release_notes_url: "https://wiki.ubuntu.com/FocalFossa/ReleaseNotes"
@@ -32,15 +31,15 @@ previous_previous_lts:
 checksums:
   desktop:
     "21.04": "fa95fb748b34d470a7cfa5e3c1c8fa1163e2dc340cd5a60f7ece9dc963ecdf88 *ubuntu-21.04-desktop-amd64.iso"
-    "20.04.2.0": "93bdab204067321ff131f560879db46bee3b994bf24836bb78538640f689e58f *ubuntu-20.04.2.0-desktop-amd64.iso"
+    "20.04.3": "5fdebc435ded46ae99136ca875afc6f05bde217be7dd018e1841924f71db46b5 *ubuntu-20.04.3-desktop-amd64.iso"
   live-server:
     "21.04": "e4089c47104375b59951bad6c7b3ee5d9f6d80bfac4597e43a716bb8f5c1f3b0 *ubuntu-21.04-live-server-amd64.iso"
-    "20.04.2": "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423 *ubuntu-20.04.2-live-server-amd64.iso"
+    "20.04.3": "f8e3086f3cea0fb3fefb29937ab5ed9d19e767079633960ccb50e76153effc98 *ubuntu-20.04.3-live-server-amd64.iso"
   desktop-arm64+raspi:
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
     "21.04": "3df85b93b66ccd2d370c844568b37888de66c362eebae5204bf017f6f5875207 *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz"
-    "20.04.2": "31884b07837099a5e819527af66848a9f4f92c1333e3ef0693d6d77af66d6832 *ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz"
+    "20.04.3": "7e405f473d8a9e3254cd702edaeecd5509a85cde1e9e99e120f6c82156c6958f *ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
     "21.04": "c9a9a5177a03fcbb6203b38e5c3c4e5447fd9e8891515da4146f319f04eb3495 *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz"
-    "20.04.2": "7b348d080648b8e36e1f29671afd973a0878503091b935b69828f2c7722dfb58 *ubuntu-20.04.2-preinstalled-server-armhf+raspi.img.xz"
+    "20.04.3": "1984c349d5d6b74279402325b6985587d1d32c01695f2946819ce25b638baa0e *ubuntu-20.04.3-preinstalled-server-armhf+raspi.img.xz"

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -41,10 +41,10 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <h3 class="p-card__title">Ubuntu Desktop {{ releases.lts.full_version_desktop }} LTS</h3>
+      <h3 class="p-card__title">Ubuntu Desktop {{ releases.lts.full_version }} LTS</h3>
       <div class="p-card__content">
         <p>デスクトップPCおよびノートPC向けUbuntu LTS版の最新バージョンをダウンロードいただけます。LTSはlong-term support（長期サポート）の略称です。{{ releases.lts.eol }}年 4 月までの5 年間、無料のセキュリティアップデートおよびメンテナンスアップデートが保証されています。</p>
-        <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version_desktop }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="{{ releases.lts.release_notes_url }}">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done
- Remove `releases.lts.full_version_desktop` and replace with `releases.lts.full_version` as they are one of the same now
- Bump the point release from [20.04.2|20.04.2.0] to 20.04.3

## QA
- Check the file names and checksums match the ones in the issue.
- Go to the demo
- Check that download paths to 20.04.3 all work but **the download wont yet**

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/4324

