### PR TITLE
Add inclusive naming action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -118,3 +118,17 @@ jobs:
         run: |
           yarn test-js
           bash <(curl -s https://codecov.io/bash) -cF javascript
+          
+  check-inclusive-naming:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check inclusive naming
+        uses: canonical-web-and-design/inclusive-naming@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jp.ubuntu.com website project
 
-[![CircleCI build status](https://circleci.com/gh/canonical-web-and-design/jp.ubuntu.com.svg?style=shield)](https://circleci.com/gh/canonical-web-and-design/jp.ubuntu.com) [![Code coverage](https://codecov.io/gh/canonical-web-and-design/jp.ubuntu.com/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/jp.ubuntu.com)
+[![CircleCI build status](https://circleci.com/gh/canonical-web-and-design/jp.ubuntu.com.svg?style=shield)](https://circleci.com/gh/canonical-web-and-design/jp.ubuntu.com) [![Code coverage](https://codecov.io/gh/canonical-web-and-design/jp.ubuntu.com/branch/main/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/jp.ubuntu.com)
 
 The codebase behind https://jp.ubuntu.com.
 


### PR DESCRIPTION
## Work done

- Adds inclusive naming github action
- Replaces key non-inclusive language

## TODO

- Rename 'master' to 'main'

## QA

- Check github action works
- Check language changes make lexical sense

## Issue

- Fixes: https://app.zenhub.com/workspaces/-web-squad-5931746dba512f05402b61f6/issues/canonical-web-and-design/web-squad/4488

