### PR TITLE
Replace CN subscription by JP one

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -34,7 +34,7 @@
         </span>
 
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" name="cNblogsubscription" value="true" />
+        <input type="hidden" name="jPblogsubscription" value="true" />
 
         <input value="3659" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
         <input value="3659" class="mktoField mktoFieldDescriptor" name="formVid" type="hidden">


### PR DESCRIPTION
## Done

People going through this form are receiving the Chinese newsletter instead of the Japanese one.

This replaces the CN blog subscription field with the JP one.

## QA

Ensure what we send through the form matches the [backend](https://engage-sj.marketo.com/?munchkinId=066-EOV-335#/classic/FO3659A1LA1).

![Screenshot from 2021-10-15 10-37-38](https://user-images.githubusercontent.com/18480003/137458374-cf99a26d-38e1-4e49-b825-517bfb6cfe46.png)

Leads coming through should have the following field set to true:

![Screenshot from 2021-10-15 10-39-49](https://user-images.githubusercontent.com/18480003/137458710-424153e6-22ce-4f6c-941d-bb4d429010c7.png)

