### PR TITLE
Add newsletter signup to blog posts and download/thankyou page

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test-python": "python3 -m unittest discover tests",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/css/modules static/js/modules",
     "watch": "yarn run watch-css && yarn run watch-js",
-    "watch-js": "watch -p 'static/js/**/*.js' -p 'static/js/third-party/**/*.js' -c 'webpack --env.development'",
+    "watch-js": "watch -p 'static/js/**/*.js' -p 'static/js/third-party/**/*.js' -c 'webpack --env=development'",
     "watch-css": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "build-css": "sass static/sass/styles.scss static/css/styles.css --load-path=node_modules --style=compressed && postcss --no-map --use autoprefixer --replace 'static/css/**/*.css'",
     "build-js": "mkdir -p static/dist && webpack",

--- a/static/js/form-validation.js
+++ b/static/js/form-validation.js
@@ -14,13 +14,15 @@ const backgroundSubmitHandlerClosure = function () {
 
     // get form
     var marketoForm = document.getElementById(submitEvent.target.id);
+    // Check if there is any errors in the from before submit
+    if (global.$(`#${submitEvent.target.id}`).valid()) {
+      // Change the form's action location
+      marketoForm.action =
+        "https://app-sjg.marketo.com/index.php/leadCapture/save2";
 
-    // Change the form's action location
-    marketoForm.action =
-      "https://app-sjg.marketo.com/index.php/leadCapture/save2";
-
-    // Submit the form in the background
-    backgroundSubmit(marketoForm);
+      // Submit the form in the background
+      backgroundSubmit(marketoForm);
+    }
   };
 };
 

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -15,6 +15,9 @@
       <p>by {{ article.author.name }} on {{ article.date }}</p>
       {{ article.content.rendered|safe }}
     </div>
+    <div class="col-4">
+      {% include 'blog/newsletter-form.html' %}
+    </div>
   </div>
 </section>
 

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -26,6 +26,9 @@
         ダウンロードを確認するか、<a class="p-link--external" href="{% if platform == 'live-server' %}https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server{% else %}https://ubuntu.com/tutorials/tutorial-install-ubuntu-desktop{% endif %}">インストールに関するヘルプ</a>をご覧ください。
       </p>
     </div>
+    <div class="col-4">
+      {% include 'blog/newsletter-form.html' %}
+    </div>
   </div>
 </section>
 

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -26,9 +26,11 @@
         ダウンロードを確認するか、<a class="p-link--external" href="{% if platform == 'live-server' %}https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server{% else %}https://ubuntu.com/tutorials/tutorial-install-ubuntu-desktop{% endif %}">インストールに関するヘルプ</a>をご覧ください。
       </p>
     </div>
-    <div class="col-4">
-      {% include 'blog/newsletter-form.html' %}
-    </div>
+    {% if platform != 'live-server' %}
+      <div class="col-4">
+        {% include 'blog/newsletter-form.html' %}
+      </div>
+    {% endif %}
   </div>
 </section>
 
@@ -198,6 +200,7 @@
     </div>
   </section>
 
+  {% if platform == 'live-server' %}
   <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
   <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
   <script>
@@ -211,6 +214,7 @@
     });
   </script>
   <script src="{{ versioned_static('js/dist/forms.js') }}"></script>
+  {% endif %}
 
   {% if version %}
     <script src="https://ubuntu.com/static/js/build/image-download.min.js"></script>


### PR DESCRIPTION
## Done

- Adds newsletter signup to blog posts and download/thankyou page as per [brief](https://docs.google.com/document/d/1yIxOPbX-2FJpnO5fjwIZ-p6UZcRvKYw0p4U_ogg8hDM/edit)


## QA

[Demo](https://jp-ubuntu-com-351.demos.haus/)
- Check newsletter sign up appears on all blog posts and on the /download/thankyou pages.

## Issue / Card

Fixes: https://github.com/canonical-web-and-design/web-squad/issues/4559

## Screenshots

![image](https://user-images.githubusercontent.com/58276363/139267897-f8a64a60-a71a-4fb2-8cee-8606b0c981b1.png)
![image](https://user-images.githubusercontent.com/58276363/139268012-c4b2e0e6-7fca-437e-b983-ae83d53d5fe5.png)
