### PR TITLE
Fix scripts on download page

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint-js": "eslint static/js",
     "format-js": "prettier -w 'static/js/**/*.{js,jsx,ts,tsx}'",
     "test-python": "python3 -m unittest discover tests",
-    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/css/modules static/js/modules",
+    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite static/js/dist static/css/modules static/js/modules",
     "watch": "yarn run watch-css && yarn run watch-js",
     "watch-js": "watch -p 'static/js/**/*.js' -p 'static/js/third-party/**/*.js' -c 'webpack --env=development'",
     "watch-css": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -31,5 +31,3 @@
     </form>
   </div>
 </div>
-
-<script src="{{ versioned_static('js/dist/forms.js') }}"></script>

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -188,24 +188,4 @@
       </div>
     </div>
   </section>
-
-  {% if platform == 'live-server' %}
-  <script src="{{ versioned_static('js/dist/forms.js') }}"></script>
-  {% endif %}
-
-  {% if version %}
-    <script src="https://ubuntu.com/static/js/build/image-download.min.js"></script>
-    <script defer>
-        var architecture = '{{ architecture }}';
-        var mirrors = {{ mirror_list | safe }};
-        var version = '{{ version }}';
-
-        if (version && architecture) {
-          var GAlabel = version + '-server-' + architecture;
-          var imagePath = version + '/ubuntu-' + version + '-live-server-' + architecture + '.iso';
-          window.initImageDownload(mirrors, imagePath, GAlabel);
-           }
-    </script>
-  {% endif %}
-
-  {% endblock %}
+{% endblock %}


### PR DESCRIPTION
## Done

These scripts are not required on jp.ubuntu.com. The forms.js script is
for country selection which is needed in specific pages on ubuntu.com.
The image-download.js script redirects to releases.ubuntu.com so this is
not required on this site either.

## QA

- Go to /download.
- Click on all buttons and make sure that the download triggers correctly.
- Check these scripts don't cause more errors on console

## Issue / Card

Fixes https://github.com/canonical-web-and-design/jp.ubuntu.com/issues/378
