### PR TITLE
Bump the point release to 20.04.4

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -11,7 +11,7 @@ lts:
   slug: FocalFossa
   name: "Focal Fossa"
   short_version: "20.04"
-  full_version: "20.04.3"
+  full_version: "20.04.4"
   release_date: "April 2020"
   eol: "April 2025"
   release_notes_url: "https://wiki.ubuntu.com/FocalFossa/ReleaseNotes"
@@ -31,17 +31,17 @@ previous_previous_lts:
 checksums:
   desktop:
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
-    "20.04.3": "5fdebc435ded46ae99136ca875afc6f05bde217be7dd018e1841924f71db46b5 *ubuntu-20.04.3-desktop-amd64.iso"
+    "20.04.4": "f92f7dca5bb6690e1af0052687ead49376281c7b64fbe4179cc44025965b7d1c *ubuntu-20.04.4-desktop-amd64.iso"
   live-server:
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
-    "20.04.3": "f8e3086f3cea0fb3fefb29937ab5ed9d19e767079633960ccb50e76153effc98 *ubuntu-20.04.3-live-server-amd64.iso"
+    "20.04.4": "28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad *ubuntu-20.04.4-live-server-amd64.iso"
   desktop-arm64+raspi:
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
-    "20.04.3": "7e405f473d8a9e3254cd702edaeecd5509a85cde1e9e99e120f6c82156c6958f *ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz"
+    "20.04.4": "6aeba20c00ef13ee7b48c57217ad0d6fc3b127b3734c113981d9477aceb4dad7 *ubuntu-20.04.4-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
-    "20.04.3": "1984c349d5d6b74279402325b6985587d1d32c01695f2946819ce25b638baa0e *ubuntu-20.04.3-preinstalled-server-armhf+raspi.img.xz"
+    "20.04.4": "3b1704e8e4ff8e01dd89b9dd6adf9b99b48b2a7530d6f7676ce8c37772ff4178 *ubuntu-20.04.4-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"


### PR DESCRIPTION
## Done

- Bump the point release from 20.04.3 to 20.04.4

## QA

- Check the file names and checksums match the ones in [the issue](https://github.com/canonical-web-and-design/web-squad/issues/4841#issuecomment-1049688375).
- Visit:
  - /download
- See that any links to download point to the links given in the issue
  - **Note:** The download **won't** work yet

## Issue / Card

Fixes [#4841](https://github.com/canonical-web-and-design/web-squad/issues/4841)