### PR TITLE
Update download thank-you and newsletter sign up headings

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -5,7 +5,7 @@
 
   <div class="blog-p-card__content">
     <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_3659" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-      <h3 class="p-card--title p-heading--4">Ubuntuニュースレターを購読</h3>
+      <h3 class="p-card--title p-heading--4">Ubuntuニュースレターの配信登録</h3>
 
       <div>
         <label>

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -14,7 +14,10 @@
         </label>
       </div>
 
-      <label for="canonicalUpdatesOptIn"><input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox">Canonical の製品やサービスについての情報を受け取ることに同意します。</label>
+      <label class="p-checkbox">
+        <input class="p-checkbox__input" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
+        <span class="p-checkbox__label" id="canonicalUpdatesOptIn">Canonical の製品やサービスについての情報を受け取ることに同意します。</span>
+      </label>
 
       <p>
         <small>お客様が購読登録を行われる場合、以下の条件に同意されたことになります。<a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonicalのプライバシーに関するお知らせ</a><a href="https://ubuntu.com/legal/data-privacy">個人情報保護ポリシー</a></small>

--- a/templates/cloudnativedasytokyo2020.html
+++ b/templates/cloudnativedasytokyo2020.html
@@ -147,7 +147,10 @@
               <input required="" id="phone" name="phone" maxlength="255" type="tel" aria-label="Phone Number">
             </li>
             <li>
-              <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox"><label for="canonicalUpdatesOptIn">Canonical の製品やサービスについての情報を受け取ることに同意します。</label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">Canonical の製品やサービスについての情報を受け取ることに同意します。
+                <span class="p-checkbox__label"  id="canonicalUpdatesOptIn"></span>
+            </label>
             </li>
             <li>
               <p> 私は、このフォームの送信により、本プレゼントへの応募において応募規約、<a href="https://assets.ubuntu.com/v1/dbd44952-CloudNative+Days+Tokyo+Raffle+2020+-+Terms+and+Conditions+.pdf">規約と条件</a>, <a href="https://ubuntu.com/legal/data-privacy/contact">Canonicalのプライバシーポリシー</a>、<a href="https://ubuntu.com/legal/data-privacy">Canonicalのプライバシーについての通知</a>を順守し、受諾することに同意します。

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -43,7 +43,7 @@
   <div class="row">
     <div class="col-7">
       <p>
-        Ubuntu Serverに関する最新情報を毎週お届けします：
+        Ubuntu Serverに関する最新情報を毎週お届けします:
       </p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">セキュリティ情報</li>
@@ -150,7 +150,7 @@
     <div class="row">
       <div class="col-8">
         <h2>
-          本番環境でUbuntuを使用していますか？
+          本番環境でUbuntuを使用していますか?
         </h2>
         <ul class="p-list">
           <li class="p-list__item is-ticked">電話およびチケットによるサポート</li>

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -38,7 +38,7 @@
 {% if platform == 'live-server' %}
 <section class="p-strip is-bordered">
   <div class="row">
-    <h2>Ubuntuニュースレターを購読</h2>
+    <h2>Ubuntuニュースレターの配信登録</h2>
   </div>
   <div class="row">
     <div class="col-7">
@@ -65,7 +65,7 @@
     <div class="col-5">
       <!-- insert form -->
       <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_3649" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-        <h3 class="p-card--title p-heading--4">Ubuntuニュースレターを購読</h3>
+        <h3 class="p-card--title p-heading--4">Ubuntuニュースレターの配信登録</h3>
 
         <div>
           <label>

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -76,9 +76,9 @@
 
         <div>
           <span>
-            <input class="u-no-margin--top" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-            <label for="canonicalUpdatesOptIn" class="p-form__label u-no-margin--top">
-              <small>Canonicalの製品とサービスに関する情報を受け取ることに同意します。</small>
+            <label class="p-checkbox">
+              <input class="p-checkbox__input u-no-margin--top" value="yes" aria-labelledby="canonicalUpdatesOptIn" type="checkbox" />
+              <span class="p-checkbox__label" id="canonicalUpdatesOptIn"><small>Canonicalの製品とサービスに関する情報を受け取ることに同意します。</small></span>
             </label>
           </span>
         </div>

--- a/templates/engage/shared/_form.html
+++ b/templates/engage/shared/_form.html
@@ -24,8 +24,10 @@
 
         <ul class="p-list">
           <li class="p-list__item">
-            <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-            <label for="canonicalUpdatesOptIn">不定期配信のニュースメールを希望の方はこちらをチェックください。</label> <!-- I would like to receive occasional news from Canonical by email. -->
+            <label class="p-checkbox">
+              <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" type="checkbox">
+              <span class="p-checkbox__label" id="canonicalUpdatesOptIn">不定期配信のニュースメールを希望の方はこちらをチェックください。</span>
+            </label> <!-- I would like to receive occasional news from Canonical by email. -->
           </li>
           <li class="p-list__item">
             <p><a href="https://ubuntu.com/legal" target="_blank">記載頂いた情報はCanonicalの個人情報保護ポリシーに基づき管理いたします。</a>.</p>


### PR DESCRIPTION
## Done

Updates the headings for the download thank-you and newsletter sign up.
Old: Ubuntuニュースレターを購読
New: Ubuntuニュースレターの配信登録

## QA
 
Use find tool to check for instances of the old heading. And check the following pages have the new heading:
https://jp.ubuntu.com/blog
https://jp.ubuntu.com/download/thank-you?version=20.04.4&architecture=amd64&platform=desktop
https://jp.ubuntu.com/download/thank-you?version=21.10&architecture=amd64&platform=desktop
https://jp.ubuntu.com/download/thank-you?version=20.04.4&architecture=amd64&platform=live-server
https://jp.ubuntu.com/download/thank-you?version=21.10&architecture=amd64&platform=live-server

Check the forms that had there checkboxes updated


## Issue / Card

https://github.com/canonical-web-and-design/jp.ubuntu.com/issues/390
