### PR TITLE
Add API key to enable access to functionality that requires privileges

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -8,6 +8,16 @@ env:
   - name: SENTRY_DSN
     value: https://5d270c51e9a946b6ae1bb0155498738d@sentry.is.canonical.com//12
 
+  - name: DISCOURSE_API_KEY
+    secretKeyRef:
+      key: ubuntu-api-key
+      name: discourse-api
+
+  - name: DISCOURSE_API_USERNAME
+    secretKeyRef:
+      key: ubuntu-api-username
+      name: discourse-api
+
 readinessPath: "/"
 
 # Overrides for production

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -6,6 +6,7 @@ A Flask application for jp.ubuntu.com
 import yaml
 import flask
 import talisker
+import os
 import webapp.template_utils as template_utils
 
 from canonicalwebteam.blog import build_blueprint, BlogViews, BlogAPI
@@ -45,6 +46,8 @@ app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
     session=session,
+    api_key=os.getenv("DISCOURSE_API_KEY"),
+    api_username=os.getenv("DISCOURSE_API_USERNAME"),
 )
 
 engage_path = "/engage"


### PR DESCRIPTION
## Done

Some discourse API features namely the discourse plugin data-explorer that will be used in [new engage pages]() and blocking google search from [indexing discourse posts](https://github.com/canonical-web-and-design/web-squad/issues/5661) require discourse API keys.

## QA

No QA really, once we merge this, we can change the permissions so that engage pages are not accessible without login, but this can only happen after merge.

Just check that `/engage` works and check the individual engage pages work

## Issue / Card

Partially https://github.com/canonical-web-and-design/web-squad/issues/5661
Partially https://github.com/canonical-web-and-design/ubuntu.com/issues/11503

