### PR TITLE
chore: bump cookie policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "webpack-cli": "5.0.1"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "^3.6.4",
+    "@canonical/cookie-policy": "3.7.3",
     "@canonical/global-nav": "3.4.0",
     "vanilla-framework": "4.21.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,10 +1063,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@^3.6.4":
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.4.tgz#895c3770f621b73d88b0d5843c43a32d99e4a462"
-  integrity sha512-kfwamTpAaBhtH5TzlMb8wE814a8lIbONUuSYnS7VPiHDfcdmw4NoBPNpldmNY1j3CAT5vMKOx5kulRTWpEXpag==
+"@canonical/cookie-policy@3.7.3":
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.7.3.tgz#65db73735f7ee565fff37013fd2c2de7bce85648"
+  integrity sha512-6Ycnu0nEgaV5uFplZwHg5mkOQ6HicbXAIb4+I8UH3EXqGCPAuVcfTgd4eunZzmQahVmtNZethNjF/mUoU9Fa6A==
 
 "@canonical/global-nav@3.4.0":
   version "3.4.0"


### PR DESCRIPTION
## Done

- Bump cookie policy version to modernize cookie popup

## QA

- Go to demo link
- See that the cookie notification pops up as a banner
- Click around and ensure that the new cookie policy works as expected
- Scroll down to "Manage your tracker settings"
- See that the notification pops up as expected
- Repeat on medium and small screens 

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
