### PR TITLE
Update: Cookie-policy package to 3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "webpack-cli": "5.0.1"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "git+https://github.com/canonical/cookie-policy.git#WD-31846-fix-cookie-banner-on-c-com-and-jp-ubuntu-com",
+    "@canonical/cookie-policy": "3.8.3",
     "@canonical/global-nav": "3.4.0",
     "vanilla-framework": "4.21.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,10 +1063,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.8.2.tgz#5a2fec4eede97773d0c96b5de883fdc633d96d54"
-  integrity sha512-nQRBi9KO5j8NqOzzcYU01e9TLyYcbBCzN3W375vDMXYD7g6IQzsJJxf6eu0vMQxXfD3JBUJ6zSnYbk6Z88Al7A==
+"@canonical/cookie-policy@3.8.3":
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.8.3.tgz#f8edf020c1737c263e332b97ff79c0eb8a98eadc"
+  integrity sha512-tY+0t3prlmZqrOnYFVhbH4tKf4ylCBILcWRupJdoNvH/DJCsROtfAEDEPgZlH6F+YGimdbfa4zraqsKx4Vt+Rw==
 
 "@canonical/global-nav@3.4.0":
   version "3.4.0"


### PR DESCRIPTION
## Done

- Update: Cookie-policy package to 3.8.3

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8012/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- See [demo](https://jp-ubuntu-com-519.demos.haus/) if cookie works as expected.
