### PR TITLE
fix: Remove animation for nojs fallback takeover on jp.ubuntu.com

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,15 @@
 {% block body_class %}is-dark{% endblock body_class %}
 
 {% block outer_content %}
+
+  <noscript>
+    <style>
+      .p-takeover-animation {
+        animation: none;
+      }
+    </style>
+  </noscript>
+
   <!-- Default Takeover: Download the latest Ubuntu -->
   <section class="p-strip js-takeover is-active" id="takeover">
     <div class="row u-equal-height p-takeover-animation" id="takeover-animation">


### PR DESCRIPTION
## Done

- Added noscript for style override to remove animation for fallback takeover when JS is disabled

## QA

- Check out this PR, and run the project using `dotrun`
- Open devtools, disable Javascript and refresh the page
- Verify no animation is present on the takeover and that it loads instantly
