### PR TITLE
fix: load releases url directly

### DIFF
--- a/tests/test_releases_yaml_reference.py
+++ b/tests/test_releases_yaml_reference.py
@@ -16,8 +16,10 @@ class TestReleasesYamlReferences(TestCase):
     def setUpClass(cls):
 
         with app.app_context():
-            releases_url = app.config["UBUNTU_COM_RELEASES"]
-            cls.releases_data = get_releases(releases_url)
+            cls.releases_data = get_releases(
+                "https://raw.githubusercontent.com/canonical/"
+                "ubuntu.com/main/releases.yaml"
+            )
 
         cls.valid_paths = set()
         cls._build_paths(cls.releases_data, "releases", cls.valid_paths)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -43,9 +43,6 @@ app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(days=365)
 app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
 app.config["SESSION_COOKIE_HTTPONLY"] = True
 app.config["SESSION_COOKIE_SECURE"] = True
-app.config["UBUNTU_COM_RELEASES"] = (
-    "https://raw.githubusercontent.com/canonical/ubuntu.com/main/releases.yaml"
-)
 
 
 # Initialize Flask-Caching
@@ -172,7 +169,11 @@ def takeovers_index():
 app.add_url_rule("/takeovers.json", view_func=takeovers_json)
 app.add_url_rule("/takeovers", view_func=takeovers_index)
 
-releases = get_releases(app.config["UBUNTU_COM_RELEASES"])
+# read releases.yaml
+releases = get_releases(
+    "https://raw.githubusercontent.com/canonical/"
+    "ubuntu.com/main/releases.yaml"
+)
 
 
 # Image template


### PR DESCRIPTION
## Done

- Load releases URL directly without adding it to app config
- Add error catching when loading releases from ubuntu.com releases.yaml
- Note: Update jenkins config to track changes from main branch after merge

## QA

- See that [this job](https://jenkins.canonical.com/webteam/job/jp.ubuntu.com/94/) builds successfully

## Issue / Card

Fixes [WD-35547](https://warthogs.atlassian.net/browse/WD-35547)

## Screenshots

[if relevant, include a screenshot]


[WD-35547]: https://warthogs.atlassian.net/browse/WD-35547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ