### PR TITLE
Add Ubuntu usage checkbox options in blog newsletter form

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -157,4 +157,15 @@ html {
   }
 }
 
+.blog-newsletter-checkbox-group {
+  display: flex;
+  flex-direction: column;
+
+  @media only screen and (max-width: $breakpoint-large) {
+    align-items: center;
+    flex-direction: row;
+    gap: 1rem;
+  }
+}
+
 /* stylelint-enable declaration-colon-newline-after */

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -14,6 +14,25 @@
         </label>
       </div>
 
+      <div>
+        <label id="ubuntu_planned_usage_label">Ubuntuをどのように使用する予定ですか？</label>
+        <div class="p-section--shallow" aria-labelledby="ubuntu_planned_usage_label" style="display: flex; align-items: center; gap: 24px;">
+            <label class="p-checkbox u-no-margin">
+              <input type="checkbox" name="UbuntuDesktopPlannedUsage" value="work" aria-labelledby="work" class="p-checkbox__input" />
+              <span class="p-checkbox__label" id="work">ビジネス使用</span>
+            </label>
+            <label class="p-checkbox u-no-margin">
+              <input type="checkbox" name="UbuntuDesktopPlannedUsage" value="education" aria-labelledby="education" class="p-checkbox__input" />
+              <span class="p-checkbox__label" id="education">教育使用</span>
+            </label>
+            <label class="p-checkbox u-no-margin">
+              <input type="checkbox" name="UbuntuDesktopPlannedUsage" value="personal" aria-labelledby="personal" class="p-checkbox__input" />
+              <span class="p-checkbox__label" id="personal">個人使用</span>
+            </label>
+        </div>
+        <hr class="p-rule" />
+      </div>
+
       <label class="p-checkbox">
         <input class="p-checkbox__input" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
         <span class="p-checkbox__label" id="canonicalUpdatesOptIn">Canonical の製品やサービスについての情報を受け取ることに同意します。</span>

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -16,16 +16,16 @@
 
       <div>
         <label id="ubuntu_planned_usage_label">Ubuntuをどのように使用する予定ですか？</label>
-        <div class="p-section--shallow" aria-labelledby="ubuntu_planned_usage_label" style="display: flex; align-items: center; gap: 24px;">
-            <label class="p-checkbox u-no-margin">
+        <div class="p-section--shallow blog-newsletter-checkbox-group" aria-labelledby="ubuntu_planned_usage_label">
+            <label class="p-checkbox blog-newsletter-checkbox-group__option">
               <input type="checkbox" name="UbuntuDesktopPlannedUsage" value="work" aria-labelledby="work" class="p-checkbox__input" />
               <span class="p-checkbox__label" id="work">ビジネス使用</span>
             </label>
-            <label class="p-checkbox u-no-margin">
+            <label class="p-checkbox blog-newsletter-checkbox-group__option" style="margin-top:0;">
               <input type="checkbox" name="UbuntuDesktopPlannedUsage" value="education" aria-labelledby="education" class="p-checkbox__input" />
               <span class="p-checkbox__label" id="education">教育使用</span>
             </label>
-            <label class="p-checkbox u-no-margin">
+            <label class="p-checkbox blog-newsletter-checkbox-group__option" style="margin-top:0;">
               <input type="checkbox" name="UbuntuDesktopPlannedUsage" value="personal" aria-labelledby="personal" class="p-checkbox__input" />
               <span class="p-checkbox__label" id="personal">個人使用</span>
             </label>

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -21,11 +21,11 @@
               <input type="checkbox" name="UbuntuDesktopPlannedUsage" value="work" aria-labelledby="work" class="p-checkbox__input" />
               <span class="p-checkbox__label" id="work">ビジネス使用</span>
             </label>
-            <label class="p-checkbox blog-newsletter-checkbox-group__option" style="margin-top:0;">
+            <label class="p-checkbox blog-newsletter-checkbox-group__option u-no-margin--top">
               <input type="checkbox" name="UbuntuDesktopPlannedUsage" value="education" aria-labelledby="education" class="p-checkbox__input" />
               <span class="p-checkbox__label" id="education">教育使用</span>
             </label>
-            <label class="p-checkbox blog-newsletter-checkbox-group__option" style="margin-top:0;">
+            <label class="p-checkbox blog-newsletter-checkbox-group__option u-no-margin--top">
               <input type="checkbox" name="UbuntuDesktopPlannedUsage" value="personal" aria-labelledby="personal" class="p-checkbox__input" />
               <span class="p-checkbox__label" id="personal">個人使用</span>
             </label>


### PR DESCRIPTION
## Done
- Adds a "How do you plan to use Ubuntu?" checkbox group (business, education, personal) to the blog newsletter form

Demo - https://telescope-heated-psi-this.trycloudflare.com/blog

[Marketo](https://experience.adobe.com/#/@canonical/so:066-EOV-335/marketo-engage/classic/SL100945143A1LA1)

Demo link blog seems to be failing so I tunneled the one above

## QA
- [x] Navigate to https://jp-ubuntu-com-552.demos.haus/blog or any blog page (Or run locally, the demo blog page seems to be down)
- [x] Verify the three checkbox options (ビジネス使用, 教育使用, 個人使用) appear between the email field and the consent checkbox
- [x] Submit the form with no checkboxes selected — confirm submission succeeds
- [x] Submit the form with one checkbox selected — confirm the value reaches Marketo
- [x] Submit the form with multiple checkboxes selected — confirm all values reach Marketo
- [x] Check the form is accessible: checkboxes are keyboard-navigable, and labels are properly associated

## Issue / Card
https://warthogs.atlassian.net/browse/WD-35608

## Screenshots

<img width="469" height="548" alt="image" src="https://github.com/user-attachments/assets/ddbea609-4df0-4893-9ef5-15568e238c19" />

### after
<img width="404" height="605" alt="image" src="https://github.com/user-attachments/assets/220d72cb-9567-4190-ab3b-b64dcd92e467" />

<img width="733" height="185" alt="image" src="https://github.com/user-attachments/assets/c2e2fff3-db95-4a4f-9e71-019d6b5a7d4a" />


[if relevant, include a screenshot]
