### PR TITLE
build: implement caching for releases

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -133,14 +133,6 @@ class TestRoutes(VCRTestCase):
 
         self.assertEqual(self.client.get("/pro").status_code, 200)
 
-    def test_download(self):
-        """
-        When given the download URL,
-        we should return a 200 status code
-        """
-
-        self.assertEqual(self.client.get("/download").status_code, 200)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/webapp/api.py
+++ b/webapp/api.py
@@ -11,10 +11,16 @@ expiry_seconds = 300
 
 cached_request = CachedSession(fallback_cache_duration=expiry_seconds)
 logger = logging.getLogger(__name__)
+RELEASES_CACHE_KEY = "releases_data"
+RELEASES_URL = (
+    "https://raw.githubusercontent.com/canonical/"
+    "ubuntu.com/main/releases.yaml"
+)
 
 
 def get_releases(url):
-    response = requests.get(url)
+    """Fetch releases.yaml from the given URL."""
+    response = requests.get(url, timeout=10)
     response.raise_for_status()
 
     data = yaml.load(response.text, Loader=yaml.FullLoader)
@@ -48,6 +54,28 @@ def get_releases(url):
                         info[key] = f"{parts[1]}年{month_map[parts[0]]}月"
 
     return data
+
+
+def get_releases_cached(cache):
+    """
+    Get releases from cache or fetch and cache if missing.
+    """
+    cached_data = cache.get(RELEASES_CACHE_KEY)
+
+    if cached_data is not None:
+        logger.debug("Releases loaded from cache")
+        return cached_data
+
+    try:
+        logger.info(f"Fetching releases from {RELEASES_URL}...")
+        data = get_releases(RELEASES_URL)
+        # Set cache to an hour
+        cache.set(RELEASES_CACHE_KEY, data, timeout=3600)
+        logger.debug("Releases fetched and cached successfully")
+        return data
+    except Exception as e:
+        logger.error(f"Failed to fetch releases: {e}")
+        raise
 
 
 def get(url):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -171,8 +171,7 @@ app.add_url_rule("/takeovers", view_func=takeovers_index)
 
 def download_releases():
     return flask.render_template(
-        "download/index.html",
-        releases=get_releases_cached(cache)
+        "download/index.html", releases=get_releases_cached(cache)
     )
 
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -20,8 +20,7 @@ from webapp.views import (
     build_engage_page,
     engage_thank_you,
 )
-
-from webapp.api import get_releases
+from webapp.api import get_releases_cached
 
 from jinja2 import ChoiceLoader, FileSystemLoader
 
@@ -169,11 +168,15 @@ def takeovers_index():
 app.add_url_rule("/takeovers.json", view_func=takeovers_json)
 app.add_url_rule("/takeovers", view_func=takeovers_index)
 
-# read releases.yaml
-releases = get_releases(
-    "https://raw.githubusercontent.com/canonical/"
-    "ubuntu.com/main/releases.yaml"
-)
+
+def download_releases():
+    return flask.render_template(
+        "download/index.html",
+        releases=get_releases_cached(cache)
+    )
+
+
+app.add_url_rule("/download", view_func=download_releases)
 
 
 # Image template
@@ -191,7 +194,6 @@ def context():
         "replace_admin": template_utils.replace_admin,
         "truncate_chars": template_utils.truncate_chars,
         "page": flask.request.args.get("page", ""),
-        "releases": releases,
         "platform": flask.request.args.get("platform", ""),
         "version": flask.request.args.get("version", ""),
         "architecture": flask.request.args.get("architecture", ""),


### PR DESCRIPTION
## Done

- Cache releases
- Add url rule for download page, where releases is called. This is done to avoid blocking during project build

## QA

- Go to /download
- See that the releases are using the data from [releases.yaml](https://raw.githubusercontent.com/canonical/ubuntu.com/main/releases.yaml)
- See that [build](https://jenkins.canonical.com/webteam/job/jp.ubuntu.com/117/) passes

## Issue / Card

Fixes [WD-35934](https://warthogs.atlassian.net/browse/WD-35934)

## Screenshots

[if relevant, include a screenshot]


[WD-35934]: https://warthogs.atlassian.net/browse/WD-35934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ