### PR TITLE
Fix deployment workflow and Rockcraft build issues

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - fix/deployment # remove after approval
+      - fix/deployment-test # remove after approval
       - main
 
 env:
@@ -123,41 +123,42 @@ jobs:
           juju refresh jp-ubuntu-com-blog --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
           juju wait-for application jp-ubuntu-com --query='name=="jp-ubuntu-com" && (status=="active" || status=="idle")'
 
-  # deploy-production:
-  #   runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
-  #   needs: [pack-charm, publish-image]
-  #   steps:
-  #     - name: Checkout Code
-  #       uses: actions/checkout@v3
+  deploy-production:
+    runs-on:
+      [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
+    needs: [pack-charm, publish-image]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
 
-  #     - name: Install Dependencies
-  #       run: |
-  #         sudo snap install juju --channel=3.6/stable --classic
-  #         sudo snap install vault --classic
+      - name: Install Dependencies
+        run: |
+          sudo snap install juju --channel=3.6/stable --classic
+          sudo snap install vault --classic
 
-  #     - name: Download Charm Artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: jp-ubuntu-com-charm
+      - name: Download Charm Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: jp-ubuntu-com-charm
 
-  #     - name: Configure Vault and Juju
-  #       run: |
-  #         export VAULT_ADDR=https://vault.admin.canonical.com:8200
-  #         export TF_VAR_login_approle_role_id=${{ secrets.PROD_VAULT_APPROLE_ROLE_ID }}
-  #         export TF_VAR_login_approle_secret_id=${{ secrets.PROD_VAULT_APPROLE_SECRET_ID }}
-  #         export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/prod-jp-ubuntu-com
-  #         export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
-  #         VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id})
-  #         export VAULT_TOKEN
-  #         mkdir -p ~/.local/share/juju
-  #         vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-36-production-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
-  #         USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
-  #         PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
-  #         printf "controllers:\n  juju-controller-36-production-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
+      - name: Configure Vault and Juju
+        run: |
+          export VAULT_ADDR=https://vault.admin.canonical.com:8200
+          export TF_VAR_login_approle_role_id=${{ secrets.PROD_VAULT_APPROLE_ROLE_ID }}
+          export TF_VAR_login_approle_secret_id=${{ secrets.PROD_VAULT_APPROLE_SECRET_ID }}
+          export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/prod-jp-ubuntu-com
+          export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
+          VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id})
+          export VAULT_TOKEN
+          mkdir -p ~/.local/share/juju
+          vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-36-production-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
+          USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
+          PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
+          printf "controllers:\n  juju-controller-36-production-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
 
-  #     - name: Deploy Application to production
-  #       run: |
-  #         export JUJU_MODEL=admin/prod-jp-ubuntu-com
-  #         juju refresh jp-ubuntu-com --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-  #         juju refresh jp-ubuntu-com-blog --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-  #         juju wait-for application jp-ubuntu-com --query='name=="jp-ubuntu-com" && (status=="active" || status=="idle")'
+      - name: Deploy Application to production
+        run: |
+          export JUJU_MODEL=admin/prod-jp-ubuntu-com
+          juju refresh jp-ubuntu-com --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          juju refresh jp-ubuntu-com-blog --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          juju wait-for application jp-ubuntu-com --query='name=="jp-ubuntu-com" && (status=="active" || status=="idle")'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - samhotep-patch-2 # remove after approval
+      - fix/deployment # remove after approval
       - main
 
 env:
@@ -84,7 +84,8 @@ jobs:
         run: skopeo --insecure-policy copy oci-archive:$(ls *.rock) docker://${{ steps.set_image_url.outputs.image_url }} --dest-creds "canonical:${{ secrets.GITHUB_TOKEN }}"
 
   deploy-staging:
-    runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
+    runs-on:
+      [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
     needs: [pack-charm, publish-image]
     steps:
       - name: Checkout Code
@@ -122,41 +123,41 @@ jobs:
           juju refresh jp-ubuntu-com-blog --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
           juju wait-for application jp-ubuntu-com --query='name=="jp-ubuntu-com" && (status=="active" || status=="idle")'
 
-  deploy-production:
-    runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
-    needs: [pack-charm, publish-image]
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
+  # deploy-production:
+  #   runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
+  #   needs: [pack-charm, publish-image]
+  #   steps:
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v3
 
-      - name: Install Dependencies
-        run: |
-          sudo snap install juju --channel=3.6/stable --classic
-          sudo snap install vault --classic
+  #     - name: Install Dependencies
+  #       run: |
+  #         sudo snap install juju --channel=3.6/stable --classic
+  #         sudo snap install vault --classic
 
-      - name: Download Charm Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: jp-ubuntu-com-charm
+  #     - name: Download Charm Artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: jp-ubuntu-com-charm
 
-      - name: Configure Vault and Juju
-        run: |
-          export VAULT_ADDR=https://vault.admin.canonical.com:8200
-          export TF_VAR_login_approle_role_id=${{ secrets.PROD_VAULT_APPROLE_ROLE_ID }}
-          export TF_VAR_login_approle_secret_id=${{ secrets.PROD_VAULT_APPROLE_SECRET_ID }}
-          export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/prod-jp-ubuntu-com
-          export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
-          VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id}) 
-          export VAULT_TOKEN
-          mkdir -p ~/.local/share/juju
-          vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-36-production-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
-          USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
-          PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
-          printf "controllers:\n  juju-controller-36-production-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
+  #     - name: Configure Vault and Juju
+  #       run: |
+  #         export VAULT_ADDR=https://vault.admin.canonical.com:8200
+  #         export TF_VAR_login_approle_role_id=${{ secrets.PROD_VAULT_APPROLE_ROLE_ID }}
+  #         export TF_VAR_login_approle_secret_id=${{ secrets.PROD_VAULT_APPROLE_SECRET_ID }}
+  #         export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/prod-jp-ubuntu-com
+  #         export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
+  #         VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id})
+  #         export VAULT_TOKEN
+  #         mkdir -p ~/.local/share/juju
+  #         vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-36-production-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
+  #         USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
+  #         PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
+  #         printf "controllers:\n  juju-controller-36-production-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
 
-      - name: Deploy Application to production
-        run: |
-          export JUJU_MODEL=admin/prod-jp-ubuntu-com
-          juju refresh jp-ubuntu-com --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-          juju refresh jp-ubuntu-com-blog --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-          juju wait-for application jp-ubuntu-com --query='name=="jp-ubuntu-com" && (status=="active" || status=="idle")'
+  #     - name: Deploy Application to production
+  #       run: |
+  #         export JUJU_MODEL=admin/prod-jp-ubuntu-com
+  #         juju refresh jp-ubuntu-com --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+  #         juju refresh jp-ubuntu-com-blog --path ./jp-ubuntu-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+  #         juju wait-for application jp-ubuntu-com --query='name=="jp-ubuntu-com" && (status=="active" || status=="idle")'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+flask
 canonicalwebteam.flask-base==2.6.0
 canonicalwebteam.discourse==5.4.3
 canonicalwebteam.http==1.0.4

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,4 +17,4 @@ parts:
       - flask/app/templates
       - flask/app/webapp
       - flask/app/redirects.yaml
-      - flask/app/releases.yaml
+      # - flask/app/releases.yaml

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,4 +17,3 @@ parts:
       - flask/app/templates
       - flask/app/webapp
       - flask/app/redirects.yaml
-      # - flask/app/releases.yaml


### PR DESCRIPTION
## Done
- Add `flask` to `requirements.txt` to satisfy the `flask-framework` Rockcraft extension's dependency validation
- Remove `releases.yaml` from Rockcraft prime list (no longer present in the project)

### Context
The Rockcraft `flask-framework` extension requires `flask` to be explicitly listed in `requirements.txt`. Previously it was only pulled in transitively via `canonicalwebteam.flask-base`, which caused a CI build failure: "missing flask package dependency in requirements file."

## QA
https://github.com/canonical/jp.ubuntu.com/actions/runs/24335153160
- Verify `rockcraft pack` succeeds in CI without the missing flask dependency error
- Verify staging deployment completes successfully

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
