### PR TITLE
fix: broken engage pages and blogs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -68,6 +68,9 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     needs: pack-rock
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_url: ${{ steps.set_image_url.outputs.image_url }}
     steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,6 @@ name: Deploy
 on:
   push:
     branches:
-      - fix/deployment-test # remove after approval
       - main
 
 env:

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -35,4 +35,6 @@ config:
     cookie-service-api-key:
       description: "Cookie Service API Key"
       type: secret
-      
+    wordpress:
+      type: secret
+      description: "Wordpress credentials"

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -34,18 +34,14 @@ env:
       key: wordpress-username
       name: wordpress-api
 
-# Overrides for demo
-demo:
-  env:
-    - name: HTTP_PROXY
-      value: http://squid.internal:3128
-    
-    - name: HTTPS_PROXY
-      value: http://squid.internal:3128
-    
+  - name: HTTP_PROXY
+    value: http://squid.internal:3128
+  
+  - name: HTTPS_PROXY
+    value: http://squid.internal:3128
 
-    - name: NO_PROXY
-      value: "10.24.0.132,10.24.0.23,.internal,admin.insights.ubuntu.com,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,canonical.design,.canonical.design"
+  - name: NO_PROXY
+    value: "10.24.0.132,10.24.0.23,.internal,admin.insights.ubuntu.com,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,canonical.design,.canonical.design"
 
 # Overrides for production
 production:
@@ -73,7 +69,7 @@ production:
 
   nginxConfigurationSnippet: |
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
-  
+
 
 # Overrides for staging
 staging:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -24,6 +24,16 @@ env:
       key: cookies-api-key
       name: cookies-canonical-com-credentials
 
+  - name: WORDPRESS_APPLICATION_PASSWORD
+    secretKeyRef:
+      key: wordpress-application-password
+      name: wordpress-api
+
+  - name: WORDPRESS_USERNAME
+    secretKeyRef:
+      key: wordpress-username
+      name: wordpress-api
+
 # Overrides for demo
 demo:
   env:
@@ -32,6 +42,10 @@ demo:
     
     - name: HTTPS_PROXY
       value: http://squid.internal:3128
+    
+
+    - name: NO_PROXY
+      value: "10.24.0.132,10.24.0.23,.internal,admin.insights.ubuntu.com,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,canonical.design,.canonical.design"
 
 # Overrides for production
 production:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 flask
 canonicalwebteam.flask-base==2.6.0
-canonicalwebteam.discourse==5.4.3
+canonicalwebteam.discourse==7.2.0
 canonicalwebteam.http==1.0.4
-canonicalwebteam.blog==6.8.2
+canonicalwebteam.blog==6.8.4
 canonicalwebteam.image-template==1.9.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.cookie-service==2.0.1

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -17,7 +17,7 @@
 
 <section class="p-strip is-shallow" id="posts-list">
   <div class="row u-equal-height">
-    {% for item in metadata %}
+    {% for item in metadata[0] %}
       {% with 
       title=item.topic_name,
       title_link=item.path,

--- a/templates/engage/shared/_article-card.html
+++ b/templates/engage/shared/_article-card.html
@@ -1,13 +1,13 @@
 <article class="col-4 blog-p-card--post">
     <header class="blog-p-card__header{% if 'whitepaper' in type %}--internet-of-things{% elif 'webinar' in type %}--desktop{% elif 'case study' in type %}--cloud-and-server{% endif %}">
       <h5 class="p-muted-heading u-no-margin--bottom">
-        {{type}}
+        {{ type }}
       </h5>
     </header>
     <div class="blog-p-card__content">
         <h4>
-        <a href="{{title_link}}" >{{title | safe}}</a>
+        <a href="{{title_link}}" >{{ title | safe }}</a>
         </h4>
-        <p class="u-no-padding--bottom u-hide--small">{{description | safe}}</p>
+        <p class="u-no-padding--bottom u-hide--small">{{ description | safe }}</p>
     </div>
 </article>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 from canonicalwebteam.blog import build_blueprint, BlogViews, BlogAPI
 from canonicalwebteam.discourse import DiscourseAPI, EngagePages
 from canonicalwebteam.flask_base.app import FlaskBase
+from canonicalwebteam.flask_base.env import get_flask_env
 from canonicalwebteam.templatefinder import TemplateFinder
 from canonicalwebteam import image_template
 from webapp.views import (

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -5,7 +5,6 @@ A Flask application for jp.ubuntu.com
 # Packages
 import flask
 import talisker
-import os
 import webapp.template_utils as template_utils
 from flask_caching import Cache
 from datetime import timedelta

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -91,6 +91,8 @@ blog_views = BlogViews(
         api_url="https://ubuntu.com/blog/wp-json/wp/v2",
         thumbnail_width=354,
         thumbnail_height=180,
+        wordpress_username=get_flask_env("WORDPRESS_USERNAME"),
+        wordpress_password=get_flask_env("WORDPRESS_APPLICATION_PASSWORD"),
     ),
     blog_title="Ubuntu blog",
     tag_ids=[3184],
@@ -105,8 +107,8 @@ discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
     session=session,
     get_topics_query_id=16,
-    api_key=os.getenv("DISCOURSE_API_KEY"),
-    api_username=os.getenv("DISCOURSE_API_USERNAME"),
+    api_key=get_flask_env("DISCOURSE_API_KEY"),
+    api_username=get_flask_env("DISCOURSE_API_USERNAME"),
 )
 
 takeovers_path = "/takeovers"


### PR DESCRIPTION
## Done

- Add Wordpress credentials and authentication
- Add top level proxy env variables for production, staging and demos
- Update flask env function usage
- Fly-by work:
  - Bumped blog and Discourse modules
  - Add permissions to deploy image on GH

## QA

- Go to https://jp-ubuntu-com-558.demos.haus/blog
- See that individual blog articles are loading
- Go to https://jp-ubuntu-com-558.demos.haus/engage
- See that it loads as expected

## Issue / Card

Fixes [WD-36662](https://warthogs.atlassian.net/browse/WD-36662)

## Screenshots

[if relevant, include a screenshot]


[WD-36662]: https://warthogs.atlassian.net/browse/WD-36662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ