### PR TITLE
feat: increase default Cache-Control max-age to 1 hour

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,7 +1,7 @@
 import unittest
-import flask
+from types import SimpleNamespace
 from vcr_unittest import VCRTestCase
-from webapp.app import app
+from webapp.app import app, set_default_cache_control
 
 
 class TestRoutes(VCRTestCase):
@@ -143,18 +143,25 @@ class TestRoutes(VCRTestCase):
         response = self.client.get("/")
         self.assertEqual(response.cache_control.max_age, 3600)
 
-    def test_explicit_cache_control_is_preserved(self):
+    def test_explicit_string_cache_control_is_preserved(self):
         """
-        Views that set their own max-age (e.g. /takeovers.json)
-        should not be overridden by the 1 hour default
+        Responses with an explicit string max-age should not be overridden
+        by the 1 hour default cache-control policy
         """
 
         with app.test_request_context("/"):
-            response = flask.make_response("ok")
-            response.cache_control.max_age = 300
-            response = app.process_response(response)
+            response = SimpleNamespace(
+                status_code=200,
+                cache_control=SimpleNamespace(
+                    no_store=False,
+                    no_cache=False,
+                    private=False,
+                    max_age="300",
+                ),
+            )
+            response = set_default_cache_control(response)
 
-        self.assertEqual(response.cache_control.max_age, 300)
+        self.assertEqual(response.cache_control.max_age, "300")
 
 
 if __name__ == "__main__":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,4 +1,5 @@
 import unittest
+import flask
 from vcr_unittest import VCRTestCase
 from webapp.app import app
 
@@ -132,6 +133,28 @@ class TestRoutes(VCRTestCase):
         """
 
         self.assertEqual(self.client.get("/pro").status_code, 200)
+
+    def test_default_cache_control_is_one_hour(self):
+        """
+        Pages should be cacheable by content-cache for 1 hour,
+        overriding the 60s default from flask-base
+        """
+
+        response = self.client.get("/")
+        self.assertEqual(response.cache_control.max_age, 3600)
+
+    def test_explicit_cache_control_is_preserved(self):
+        """
+        Views that set their own max-age (e.g. /takeovers.json)
+        should not be overridden by the 1 hour default
+        """
+
+        with app.test_request_context("/"):
+            response = flask.make_response("ok")
+            response.cache_control.max_age = 300
+            response = app.process_response(response)
+
+        self.assertEqual(response.cache_control.max_age, 300)
 
 
 if __name__ == "__main__":

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -84,6 +84,23 @@ def set_cache(key, value, timeout):
 # )
 
 
+# Default to 1h caching, overriding flask-base's 60s default.
+# Responses that set their own max-age or opt out are untouched.
+@app.after_request
+def set_default_cache_control(response):
+    if (
+        response.status_code == 200
+        and not flask.request.path.startswith("/_status")
+        and not response.cache_control.no_store
+        and not response.cache_control.no_cache
+        and not response.cache_control.private
+        and type(response.cache_control.max_age) is not int
+    ):
+        response.cache_control.max_age = 3600
+
+    return response
+
+
 blog_views = BlogViews(
     api=BlogAPI(
         session=session,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -94,7 +94,7 @@ def set_default_cache_control(response):
         and not response.cache_control.no_store
         and not response.cache_control.no_cache
         and not response.cache_control.private
-        and type(response.cache_control.max_age) is not int
+        and response.cache_control.max_age is None
     ):
         response.cache_control.max_age = 3600
 


### PR DESCRIPTION
## Done

- Set the default `Cache-Control: max-age` to 3600s (was flask-base's 60s default), so content-cache can cache pages for 1 hour
- Registered as an `after_request` hook that runs before flask-base's, which then skips its 60s default; `stale-while-revalidate`/`stale-if-error` are still applied
- Views that set their own `max-age` (e.g. `/takeovers.json`) or opt out via `no-store`/`no-cache`/`private` are untouched; `/_status` stays `no-store`
- Added tests for the 1h default and for explicit max-age being preserved

## QA

- Run the site and check `curl -sI https://jp-ubuntu-com-570.demos.haus/ | grep -i cache-control` returns `max-age=3600, stale-while-revalidate=86400, stale-if-error=300`
- Check `/_status/check` still returns `no-store`


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
