### PR TITLE
fix: remove failing link

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -920,7 +920,7 @@
 
       {%- if slot == 'list_item_description_1' -%}
         <p>
-          オープンソースを作るのは、コントリビューターとコミュニティ内の協力です。CanonicalはOpenStackコミュニティの長期的なメンバーです。OpenStackのコードへの<a href="https://www.stackalytics.io/?release=all&metric=commits">最大級のコントリビューター</a>であると同時に、<a href="https://openinfra.dev/">Open Infrastructure Foundation</a>のゴールドメンバーでもあります。Canonicalは他のリーダーとともに、OpenStackを新しい試練に向けて常に進化させています。
+          オープンソースを作るのは、コントリビューターとコミュニティ内の協力です。CanonicalはOpenStackコミュニティの長期的なメンバーです。OpenStackのコードへの最大級のコントリビューターであると同時に、<a href="https://openinfra.dev/">Open Infrastructure Foundation</a>のゴールドメンバーでもあります。Canonicalは他のリーダーとともに、OpenStackを新しい試練に向けて常に進化させています。
         </p>
       {%- endif -%}
 


### PR DESCRIPTION
## Done

- Remove failing link as per [copy doc](https://docs.google.com/document/d/1wkXMN1OeBp9mqY5lA7ImrTIADSJ9wi55/edit?disco=AAACEJwJDFc)

## QA

- Go to /openstack
- See that the link to "[最大級のコントリビューター](https://www.stackalytics.io/?release=all&metric=commits)" is removed

## Issue / Card

Fixes [WD-37937](https://warthogs.atlassian.net/browse/WD-37937)

## Screenshots

[if relevant, include a screenshot]


[WD-37937]: https://warthogs.atlassian.net/browse/WD-37937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ